### PR TITLE
Revert "basic homepage outline"

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,16 +1,33 @@
 import { useState } from 'react'
+import reactLogo from './assets/react.svg'
+import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
+  const [count, setCount] = useState(0)
 
   return (
     <>
-      <h1>StickerCreate</h1>
-      <p>Welcome to your Personal Emote Studio.</p>
-      <div className="card">
-        <button> Log In </button>
-        <button> Create Account </button>
+      <div>
+        <a href="https://vite.dev" target="_blank">
+          <img src={viteLogo} className="logo" alt="Vite logo" />
+        </a>
+        <a href="https://react.dev" target="_blank">
+          <img src={reactLogo} className="logo react" alt="React logo" />
+        </a>
       </div>
+      <h1>Vite + React</h1>
+      <div className="card">
+        <button onClick={() => setCount((count) => count + 1)}>
+          count is {count}
+        </button>
+        <p>
+          Edit <code>src/App.jsx</code> and save to test HMR
+        </p>
+      </div>
+      <p className="read-the-docs">
+        Click on the Vite and React logos to learn more
+      </p>
     </>
   )
 }


### PR DESCRIPTION
Reverts agile-students-spring2026/final-team_stereoscopically#34

The homepages should be focused on the functionality of the app. Log In/Sign Up authentication should be created after. The previous pr #33 should be reverted, but it cannot because this pr was made after.