### PR TITLE
User story#10/tasks#67,69/backend preset filters and color adjustments for image

### DIFF
--- a/back-end/src/controllers/mediaController.js
+++ b/back-end/src/controllers/mediaController.js
@@ -1,5 +1,7 @@
 import {
 	addTextToImage,
+	adjustImage,
+	applyPresetImageFilter,
 	cropImage,
 	exportImage,
 	getExportDownloadContent,
@@ -25,6 +27,16 @@ export const healthCheck = (_req, res) => {
 
 export const uploadImageHandler = (req, res) => {
 	const result = uploadImage(req)
+	return sendResult(res, result)
+}
+
+export const adjustImageHandler = async (req, res) => {
+	const result = await adjustImage(req)
+	return sendResult(res, result)
+}
+
+export const applyPresetImageFilterHandler = async (req, res) => {
+	const result = await applyPresetImageFilter(req)
 	return sendResult(res, result)
 }
 

--- a/back-end/src/routes/mediaRoutes.js
+++ b/back-end/src/routes/mediaRoutes.js
@@ -2,6 +2,8 @@ import { Router } from 'express'
 
 import {
 	addTextImageHandler,
+	adjustImageHandler,
+	applyPresetImageFilterHandler,
 	cropImageHandler,
 	downloadExportHandler,
 	exportImageHandler,
@@ -16,6 +18,8 @@ const router = Router()
 
 router.get('/health', healthCheck)
 router.post('/api/upload/image', imageUpload.single('file'), uploadImageHandler)
+router.post('/api/adjust/image', adjustImageHandler)
+router.post('/api/filter/image', applyPresetImageFilterHandler)
 router.post('/api/crop/image', cropImageHandler)
 router.post('/api/export/image', exportImageHandler)
 router.post('/api/text/image', addTextImageHandler)

--- a/back-end/src/services/imageAdjustService.js
+++ b/back-end/src/services/imageAdjustService.js
@@ -1,0 +1,90 @@
+import sharp from 'sharp'
+
+const IDENTITY = [
+	[1, 0, 0],
+	[0, 1, 0],
+	[0, 0, 1],
+]
+const SEPIA_CORE = [
+	[0.393, 0.769, 0.189],
+	[0.349, 0.686, 0.168],
+	[0.272, 0.534, 0.131],
+]
+
+const blendSepiaMatrix = (strength) => {
+	const s = Math.min(1, Math.max(0, strength))
+	return SEPIA_CORE.map((row, i) =>
+		row.map((cell, j) => (1 - s) * IDENTITY[i][j] + s * cell),
+	)
+}
+
+/**
+ * Applies one-shot color adjustments (absolute parameters; no cumulative stacking).
+ * @param {Buffer} buffer
+ * @param {object} opts
+ */
+export const applyImageAdjustments = async (buffer, opts) => {
+	const {
+		brightness = 1,
+		contrast = 1,
+		saturation = 1,
+		hue = 0,
+		grayscale = 0,
+		sepia = 0,
+		sharpness = 1,
+	} = opts
+
+	let pipeline = sharp(buffer).rotate().ensureAlpha()
+
+	if (sepia > 0) {
+		pipeline = pipeline.recomb(blendSepiaMatrix(sepia))
+	}
+
+	if (grayscale >= 1) {
+		pipeline = pipeline.grayscale()
+	}
+
+	pipeline = pipeline.modulate({
+		brightness,
+		saturation,
+		hue: Number.isFinite(hue) ? hue : 0,
+	})
+
+	if (Number.isFinite(contrast) && contrast !== 1) {
+		const c = Math.min(4, Math.max(0.25, contrast))
+		pipeline = pipeline.linear(c, 128 * (1 - c))
+	}
+
+	if (Number.isFinite(sharpness) && sharpness > 1) {
+		const sigma = Math.min(3, (sharpness - 1) * 2 + 0.3)
+		pipeline = pipeline.sharpen({ sigma })
+	}
+
+	return pipeline.png().toBuffer()
+}
+
+export const PRESET_ADJUSTMENTS = {
+	noir: {
+		grayscale: 1,
+		contrast: 1.4,
+		brightness: 0.95,
+		saturation: 0,
+	},
+	sepia: {
+		sepia: 0.9,
+		contrast: 1.1,
+		brightness: 1.05,
+		saturation: 0.9,
+	},
+	vivid: {
+		saturation: 1.4,
+		contrast: 1.2,
+		brightness: 1.1,
+		sharpness: 1.1,
+	},
+	fade: {
+		contrast: 0.8,
+		brightness: 1.1,
+		saturation: 0.8,
+	},
+}

--- a/back-end/src/services/mediaService.js
+++ b/back-end/src/services/mediaService.js
@@ -6,6 +6,7 @@ ffmpeg.setFfmpegPath(ffmpegInstaller.path)
 
 import { MAX_EXPORT_DIMENSION } from '../config/constants.js'
 import { createMedia, getActiveMediaOrDeleteExpired } from './mediaStore.js'
+import { applyImageAdjustments, PRESET_ADJUSTMENTS } from './imageAdjustService.js'
 import { normalizeTextOverlayRequest, renderTextOverlayBuffer } from './textOverlayService.js'
 
 const createMediaId = (prefix = 'img') => `${prefix}_${Date.now()}_${Math.round(Math.random() * 1e9)}`
@@ -295,6 +296,143 @@ export const exportImage = async (req) => {
 		}
 	} catch {
 		return { error: { status: 500, error: 'Failed to export image.', code: 'EXPORT_FAILED' } }
+	}
+}
+
+const staticImageOnly = (media) =>
+	media.mimeType?.startsWith('image/') && media.mimeType !== 'image/gif'
+
+export const adjustImage = async (req) => {
+	const {
+		mediaId,
+		brightness,
+		contrast,
+		saturation,
+		hue,
+		grayscale,
+		sepia,
+		sharpness,
+	} = req.body ?? {}
+
+	if (!mediaId) {
+		return { error: { status: 400, error: 'Missing mediaId.', code: 'MISSING_MEDIA_ID' } }
+	}
+
+	const media = getActiveMediaOrDeleteExpired(mediaId)
+	if (!media) {
+		return { error: { status: 404, error: 'Media not found or expired.', code: 'MEDIA_NOT_FOUND' } }
+	}
+
+	if (!staticImageOnly(media)) {
+		return {
+			error: {
+				status: 400,
+				error: 'Only static images are supported (not GIF).',
+				code: 'UNSUPPORTED_MEDIA_TYPE',
+			},
+		}
+	}
+
+	const opts = {
+		brightness: brightness ?? 1,
+		contrast: contrast ?? 1,
+		saturation: saturation ?? 1,
+		hue: hue ?? 0,
+		grayscale: grayscale ?? 0,
+		sepia: sepia ?? 0,
+		sharpness: sharpness ?? 1,
+	}
+
+	const numericKeys = ['brightness', 'contrast', 'saturation', 'hue', 'grayscale', 'sepia', 'sharpness']
+	for (const k of numericKeys) {
+		const v = opts[k]
+		if (typeof v !== 'number' || !Number.isFinite(v)) {
+			return { error: { status: 400, error: 'Adjustment values must be finite numbers.', code: 'INVALID_ADJUST_PARAMS' } }
+		}
+	}
+
+	try {
+		const out = await applyImageAdjustments(media.buffer, opts)
+		const newId = createMediaId('img')
+		createMedia(newId, {
+			buffer: out,
+			mimeType: 'image/png',
+			size: out.length,
+			fileName: 'adjusted.png',
+		})
+		const meta = await sharp(out).metadata()
+		return {
+			status: 200,
+			data: {
+				id: newId,
+				type: 'image',
+				url: buildMediaUrl(req, newId),
+				mimeType: 'image/png',
+				size: out.length,
+				width: meta.width,
+				height: meta.height,
+			},
+		}
+	} catch (error) {
+		console.error('Adjust image error:', error)
+		return { error: { status: 500, error: 'Failed to adjust image.', code: 'ADJUST_FAILED' } }
+	}
+}
+
+export const applyPresetImageFilter = async (req) => {
+	const { mediaId, preset } = req.body ?? {}
+
+	if (!mediaId) {
+		return { error: { status: 400, error: 'Missing mediaId.', code: 'MISSING_MEDIA_ID' } }
+	}
+
+	const key = typeof preset === 'string' ? preset.toLowerCase() : ''
+	const presetOpts = PRESET_ADJUSTMENTS[key]
+	if (!presetOpts) {
+		return { error: { status: 400, error: 'Invalid or unsupported preset.', code: 'INVALID_PRESET' } }
+	}
+
+	const media = getActiveMediaOrDeleteExpired(mediaId)
+	if (!media) {
+		return { error: { status: 404, error: 'Media not found or expired.', code: 'MEDIA_NOT_FOUND' } }
+	}
+
+	if (!staticImageOnly(media)) {
+		return {
+			error: {
+				status: 400,
+				error: 'Only static images are supported (not GIF).',
+				code: 'UNSUPPORTED_MEDIA_TYPE',
+			},
+		}
+	}
+
+	try {
+		const out = await applyImageAdjustments(media.buffer, presetOpts)
+		const newId = createMediaId('img')
+		createMedia(newId, {
+			buffer: out,
+			mimeType: 'image/png',
+			size: out.length,
+			fileName: `preset-${key}.png`,
+		})
+		const meta = await sharp(out).metadata()
+		return {
+			status: 200,
+			data: {
+				id: newId,
+				type: 'image',
+				url: buildMediaUrl(req, newId),
+				mimeType: 'image/png',
+				size: out.length,
+				width: meta.width,
+				height: meta.height,
+				preset: key,
+			},
+		}
+	} catch (error) {
+		console.error('Preset filter error:', error)
+		return { error: { status: 500, error: 'Failed to apply preset filter.', code: 'PRESET_FILTER_FAILED' } }
 	}
 }
 

--- a/front-end/src/components/ColorFilters.jsx
+++ b/front-end/src/components/ColorFilters.jsx
@@ -1,24 +1,80 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import FilterScreen from './FilterScreen'
+import { adjustImageFromBackend } from '../services/backendImageService'
 
-function ColorFilters({ imageSrc, onApply, onCancel }) {
+const pctToFactor = (pct) => Math.min(2, Math.max(0, pct / 100))
+
+function ColorFilters({ imageSrc, mediaId, onApply, onCancel, applyError }) {
   const [brightness, setBrightness] = useState(100)
   const [contrast, setContrast] = useState(100)
   const [saturation, setSaturation] = useState(100)
   const [sharpness, setSharpness] = useState(100)
+  const [previewSrc, setPreviewSrc] = useState(imageSrc)
+  const [previewError, setPreviewError] = useState(null)
 
-  const handleApply = () => {
-    onApply?.({ brightness, contrast, saturation, sharpness })
+  useEffect(() => {
+    setPreviewSrc(imageSrc)
+  }, [imageSrc])
+
+  useEffect(() => {
+    if (!mediaId) {
+      setPreviewError('Image is not ready on the server yet.')
+      return
+    }
+    setPreviewError(null)
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      try {
+        const result = await adjustImageFromBackend({
+          mediaId,
+          brightness: pctToFactor(brightness),
+          contrast: pctToFactor(contrast),
+          saturation: pctToFactor(saturation),
+          sharpness: pctToFactor(sharpness),
+        })
+        if (cancelled || !result?.url) return
+        setPreviewSrc(`${result.url}?cb=${Date.now()}`)
+      } catch (err) {
+        if (!cancelled) {
+          setPreviewError(err?.message || 'Preview update failed.')
+        }
+      }
+    }, 220)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [mediaId, brightness, contrast, saturation, sharpness])
+
+  const handleApply = async () => {
+    if (!mediaId) return
+    try {
+      const result = await adjustImageFromBackend({
+        mediaId,
+        brightness: pctToFactor(brightness),
+        contrast: pctToFactor(contrast),
+        saturation: pctToFactor(saturation),
+        sharpness: pctToFactor(sharpness),
+      })
+      await onApply?.(result)
+    } catch (err) {
+      setPreviewError(err?.message || 'Could not apply adjustments.')
+    }
   }
 
   return (
     <FilterScreen
       title="Color Filters"
-      imageSrc={imageSrc}
+      imageSrc={previewSrc}
       onApply={handleApply}
       onCancel={onCancel}
     >
       <div className="color-filters-panel">
+        {(previewError || applyError) && (
+          <p className="validation-error" role="alert">
+            {previewError || applyError}
+          </p>
+        )}
         <div>
           <label>
             Brightness: {brightness}%

--- a/front-end/src/components/EditorContainer.jsx
+++ b/front-end/src/components/EditorContainer.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import MediaEntry from './MediaEntry'
 import ImageEditor from './ImageEditor'
 import FilterMain from './FilterMain'
@@ -10,6 +10,7 @@ import GifEditor from './GifEditor'
 import useMediaSelection, { MEDIA_SELECTION_CODES } from '../hooks/useMediaSelection'
 import useGifConversion from '../hooks/useGifConversion'
 import useImageEditingSession from '../hooks/useImageEditingSession'
+import { convertBackendImageResultToLocalMedia } from '../services/backendImageService'
 import CameraCapture from './CameraCapture'
 import PhotoPreview from './PhotoPreview'
 
@@ -53,6 +54,7 @@ function EditorContainer() {
     exportError,
     lastCropBoxPx,
     effectiveImageSrc,
+    effectiveBackendMediaId,
     resetImageEditingSessionState,
     clearCropSession,
     handleSizeSelect,
@@ -150,9 +152,37 @@ function EditorContainer() {
     setScreen(SCREENS.FILTERS_MAIN)
   }
 
-  const handleApplyFilters = () => {
-    setScreen(SCREENS.EDITOR)
-  }
+  const handleColorFiltersCommit = useCallback(
+    async (backendResult) => {
+      const { file, objectUrl } = await convertBackendImageResultToLocalMedia(backendResult, {
+        fetchErrorMessage: 'Failed to load adjusted image.',
+      })
+      if (previewUrl && previewUrl !== sourceUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+      applyTransformedImage(file, objectUrl, backendResult)
+      setScreen(SCREENS.EDITOR)
+    },
+    [applyTransformedImage, previewUrl, sourceUrl]
+  )
+
+  const handlePresetFiltersCommit = useCallback(
+    async (result) => {
+      if (!result) {
+        setScreen(SCREENS.EDITOR)
+        return
+      }
+      const { file, objectUrl } = await convertBackendImageResultToLocalMedia(result, {
+        fetchErrorMessage: 'Failed to load preset image.',
+      })
+      if (previewUrl && previewUrl !== sourceUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+      applyTransformedImage(file, objectUrl, result)
+      setScreen(SCREENS.EDITOR)
+    },
+    [applyTransformedImage, previewUrl, sourceUrl]
+  )
 
   const handleOpenSizes = () => {
     setScreen(SCREENS.PRESET_SIZES)
@@ -278,8 +308,10 @@ function EditorContainer() {
         return (
           <PresetFilters
             imageSrc={effectiveImageSrc}
-            onApply={handleApplyFilters}
+            mediaId={effectiveBackendMediaId}
+            onApply={handlePresetFiltersCommit}
             onCancel={() => setScreen(SCREENS.EDITOR)}
+            applyError={exportError}
           />
         )
       case SCREENS.ADD_TEXT:
@@ -295,8 +327,10 @@ function EditorContainer() {
         return (
           <ColorFilters
             imageSrc={effectiveImageSrc}
-            onApply={handleApplyFilters}
+            mediaId={effectiveBackendMediaId}
+            onApply={handleColorFiltersCommit}
             onCancel={() => setScreen(SCREENS.EDITOR)}
+            applyError={exportError}
           />
         )
       case SCREENS.PRESET_SIZES:

--- a/front-end/src/components/PresetFilters.jsx
+++ b/front-end/src/components/PresetFilters.jsx
@@ -1,30 +1,92 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import FilterScreen from './FilterScreen'
+import { applyPresetImageFilterFromBackend } from '../services/backendImageService'
 
-function PresetFilters({ imageSrc, onApply, onCancel }) {
+const PRESETS = [
+  { id: 'default', label: 'Original' },
+  { id: 'noir', label: 'Noir' },
+  { id: 'sepia', label: 'Sepia' },
+  { id: 'vivid', label: 'Vivid' },
+  { id: 'fade', label: 'Fade' },
+]
+
+function PresetFilters({ imageSrc, mediaId, onApply, onCancel, applyError }) {
   const [selectedStyle, setSelectedStyle] = useState('default')
+  const [previewSrc, setPreviewSrc] = useState(imageSrc)
+  const [previewError, setPreviewError] = useState(null)
 
-  const handleApply = () => {
-    onApply?.({ preset: selectedStyle })
+  useEffect(() => {
+    setPreviewSrc(imageSrc)
+  }, [imageSrc])
+
+  useEffect(() => {
+    if (selectedStyle === 'default') {
+      setPreviewSrc(imageSrc)
+      setPreviewError(null)
+      return
+    }
+    if (!mediaId) {
+      setPreviewError('Image is not ready on the server yet.')
+      return
+    }
+    setPreviewError(null)
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      try {
+        const result = await applyPresetImageFilterFromBackend({
+          mediaId,
+          preset: selectedStyle,
+        })
+        if (cancelled || !result?.url) return
+        setPreviewSrc(`${result.url}?cb=${Date.now()}`)
+      } catch (err) {
+        if (!cancelled) {
+          setPreviewError(err?.message || 'Preview update failed.')
+        }
+      }
+    }, 180)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [mediaId, selectedStyle, imageSrc])
+
+  const handleApply = async () => {
+    try {
+      if (selectedStyle === 'default') {
+        await onApply?.(null)
+        return
+      }
+      if (!mediaId) return
+      const result = await applyPresetImageFilterFromBackend({ mediaId, preset: selectedStyle })
+      await onApply?.(result)
+    } catch (err) {
+      setPreviewError(err?.message || 'Could not apply preset.')
+    }
   }
 
   return (
     <FilterScreen
       title="Preset Filters"
-      imageSrc={imageSrc}
+      imageSrc={previewSrc}
       onApply={handleApply}
       onCancel={onCancel}
     >
-      {['default', 'style1', 'style2'].map((style) => (
+      {PRESETS.map(({ id, label }) => (
         <button
-          key={style}
+          key={id}
           type="button"
-          className={`btn-secondary preset-filters-button ${selectedStyle === style ? 'active' : ''}`}
-          onClick={() => setSelectedStyle(style)}
+          className={`btn-secondary preset-filters-button ${selectedStyle === id ? 'active' : ''}`}
+          onClick={() => setSelectedStyle(id)}
         >
-          {style === 'style1' ? 'Style 1' : style === 'style2' ? 'Style 2' : 'Default'}
+          {label}
         </button>
       ))}
+      {(previewError || applyError) && (
+        <p className="validation-error" role="alert" style={{ gridColumn: '1 / -1' }}>
+          {previewError || applyError}
+        </p>
+      )}
     </FilterScreen>
   )
 }

--- a/front-end/src/services/backendImageService.js
+++ b/front-end/src/services/backendImageService.js
@@ -43,6 +43,50 @@ export const exportImageFromBackend = async ({ mediaId, width, height, letterbox
   }
 }
 
+export const adjustImageFromBackend = async ({
+  mediaId,
+  brightness = 1,
+  contrast = 1,
+  saturation = 1,
+  hue = 0,
+  grayscale = 0,
+  sepia = 0,
+  sharpness = 1,
+}) => {
+  const payload = await postJson({
+    path: '/api/adjust/image',
+    payload: { mediaId, brightness, contrast, saturation, hue, grayscale, sepia, sharpness },
+    fallbackErrorMessage: 'Image adjustment failed',
+  })
+  return {
+    id: payload?.id ?? null,
+    type: payload?.type ?? 'image',
+    url: payload?.url ?? null,
+    mimeType: payload?.mimeType ?? 'image/png',
+    size: payload?.size ?? null,
+    width: payload?.width ?? null,
+    height: payload?.height ?? null,
+  }
+}
+
+export const applyPresetImageFilterFromBackend = async ({ mediaId, preset }) => {
+  const payload = await postJson({
+    path: '/api/filter/image',
+    payload: { mediaId, preset },
+    fallbackErrorMessage: 'Preset filter failed',
+  })
+  return {
+    id: payload?.id ?? null,
+    type: payload?.type ?? 'image',
+    url: payload?.url ?? null,
+    mimeType: payload?.mimeType ?? 'image/png',
+    size: payload?.size ?? null,
+    width: payload?.width ?? null,
+    height: payload?.height ?? null,
+    preset: payload?.preset ?? preset,
+  }
+}
+
 export const cropImageFromBackend = async ({ mediaId, x, y, width, height, unit = 'ratio' }) => {
   const payload = await postJson({
     path: '/api/crop/image',


### PR DESCRIPTION
- Backend: `POST /api/adjust/image` (brightness, contrast, saturation, sharpness) and `POST /api/filter/image` (noir, sepia, vivid, fade); static images only
- Frontend: Color Filters and Preset Filters call the APIs, update preview, via existing `convertBackendImageResultToLocalMedia` + `applyTransformedImage`.


Closes #67 ; Closes #69 