### PR TITLE
Save trimmed video for later steps

### DIFF
--- a/front-end/src/components/GifEditor.jsx
+++ b/front-end/src/components/GifEditor.jsx
@@ -170,7 +170,12 @@ const GifEditor = ({ videoFile, onCancel, onConverted, onCreateGif }) => {
             </div>
 
             <div className="card-actions card-actions-spaced">
-                <button type="button" className="btn-secondary" onClick={() => onCancel?.()}>
+                <button type="button" className="btn-secondary" onClick={() => {
+                    setTrimStart(0)
+                    setTrimEnd(duration)
+                    setBackendResult(null)
+                    onCancel?.()
+                }}>
                     Cancel
                 </button>
                 <button


### PR DESCRIPTION
closes #79 

- Trimmed result is saved in backendResult state 
- Cancel resets trim state and clears stale video result 
- onConverted passes trimmed result to later edit steps 