### PR TITLE
User story#9/task#31/preserve image edits

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -444,6 +444,13 @@
   color: #1a1a1a;
 }
 
+.preset-letterbox-hint {
+  margin: 0 0 0.35rem 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: #555;
+}
+
 .preset-letterbox-row {
   display: flex;
   flex-wrap: wrap;
@@ -572,6 +579,12 @@ input[type='range']::-moz-range-thumb {
   text-align: center;
 }
 
+.session-notice {
+  margin-top: 0.5rem;
+  color: #2f6feb;
+  font-size: 0.9rem;
+}
+
 .image-editor-actions {
   align-items: stretch;
   gap: 0;
@@ -584,6 +597,13 @@ input[type='range']::-moz-range-thumb {
 }
 
 .image-editor-actions .btn-primary + .btn-primary {
+  margin-top: 0.75rem;
+}
+
+.image-editor-actions .btn-secondary {
+  width: 100%;
+  display: block;
+  text-align: center;
   margin-top: 0.75rem;
 }
 

--- a/front-end/src/components/EditorContainer.jsx
+++ b/front-end/src/components/EditorContainer.jsx
@@ -52,10 +52,15 @@ function EditorContainer() {
     setLetterboxColor,
     isExporting,
     exportError,
+    sessionNotice,
     lastCropBoxPx,
     effectiveImageSrc,
     effectiveBackendMediaId,
+    selectedPreset,
+    latestExportResult,
     resetImageEditingSessionState,
+    resetPresetExportSettings,
+    invalidateLatestExport,
     clearCropSession,
     handleSizeSelect,
     handleCropApply,
@@ -161,9 +166,10 @@ function EditorContainer() {
         URL.revokeObjectURL(previewUrl)
       }
       applyTransformedImage(file, objectUrl, backendResult)
+      invalidateLatestExport()
       setScreen(SCREENS.EDITOR)
     },
-    [applyTransformedImage, previewUrl, sourceUrl]
+    [applyTransformedImage, invalidateLatestExport, previewUrl, sourceUrl]
   )
 
   const handlePresetFiltersCommit = useCallback(
@@ -179,9 +185,10 @@ function EditorContainer() {
         URL.revokeObjectURL(previewUrl)
       }
       applyTransformedImage(file, objectUrl, result)
+      invalidateLatestExport()
       setScreen(SCREENS.EDITOR)
     },
-    [applyTransformedImage, previewUrl, sourceUrl]
+    [applyTransformedImage, invalidateLatestExport, previewUrl, sourceUrl]
   )
 
   const handleOpenSizes = () => {
@@ -203,17 +210,20 @@ function EditorContainer() {
   const renderImageEditor = () => (
     <ImageEditor
       imageSrc={effectiveImageSrc}
-      cropSourceImageSrc={sourceUrl || effectiveImageSrc}
+      cropSourceImageSrc={effectiveImageSrc}
       initialCropPx={lastCropBoxPx}
       onCropApply={handleCropApply}
       isUploading={isUploading}
       isExporting={isExporting}
       uploadError={uploadError}
       exportError={exportError}
+      sessionNotice={sessionNotice}
       onBack={handleBackToUpload}
       onOpenFilters={handleOpenFilters}
       onSize={handleOpenSizes}
       onExport={handleExport}
+      onResetExportSettings={resetPresetExportSettings}
+      showResetExportSettings={Boolean(selectedPreset || latestExportResult)}
     />
   )
 
@@ -340,6 +350,7 @@ function EditorContainer() {
             onLetterboxColorChange={setLetterboxColor}
             onSelect={handlePresetSizeSelect}
             onCancel={() => setScreen(SCREENS.EDITOR)}
+            isBusy={isExporting}
           />
         )
       default:

--- a/front-end/src/components/ImageEditor.jsx
+++ b/front-end/src/components/ImageEditor.jsx
@@ -10,10 +10,13 @@ const ImageEditor = ({
   onBack,
   onSize,
   onExport,
+  onResetExportSettings,
+  showResetExportSettings = false,
   isUploading = false,
   uploadError = null,
   isExporting = false,
   exportError = null,
+  sessionNotice = null,
 }) => {
   // Track if cropper is active
   const [isCropping, setIsCropping] = useState(false)
@@ -61,8 +64,8 @@ const ImageEditor = ({
     return (
       <div className="image-editor-container">
         <h2 className="image-editor-title">Crop Image</h2>
-        <p role="note" className="upload-status" style={{ marginTop: '0.5rem', color: '#ff9500' }}>
-          Warning: Applying a crop will remove any filters or text overlays you have applied.
+        <p role="note" className="upload-status" style={{ marginTop: '0.5rem', color: '#555' }}>
+          Cropping uses your current preview (filters and color edits included).
         </p>
         {cropError && (
           <p role="alert" className="upload-status" style={{ marginTop: '0.5rem', color: '#ff3b30' }}>
@@ -100,6 +103,11 @@ const ImageEditor = ({
           {exportError}
         </p>
       )}
+      {sessionNotice && (
+        <p role="status" className="upload-status session-notice">
+          {sessionNotice}
+        </p>
+      )}
 
       {imageLoadError && (
         <p role="alert" className="upload-status" style={{ marginTop: '0.5rem', color: '#ff3b30' }}>
@@ -121,15 +129,25 @@ const ImageEditor = ({
         )}
       </div>
       <div className="card image-editor-actions">
-        <button type="button" className="btn-primary" onClick={onSize || (() => {})}>
-          Resize
+        <button type="button" className="btn-primary" onClick={onOpenFilters}>
+          Filters
         </button>
         <button type="button" className="btn-primary" onClick={handleCropClick}>
           Crop
         </button>
-        <button type="button" className="btn-primary" onClick={onOpenFilters}>
-          Filters
+        <button type="button" className="btn-primary" onClick={onSize || (() => {})}>
+          Resize
         </button>
+        {showResetExportSettings && (
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => onResetExportSettings?.()}
+            disabled={isExporting}
+          >
+            Reset resize
+          </button>
+        )}
       </div>
       <div className="card-actions card-actions-spaced">
         <button type="button" className="btn-secondary" onClick={onBack}>

--- a/front-end/src/components/PresetSizes.jsx
+++ b/front-end/src/components/PresetSizes.jsx
@@ -11,7 +11,7 @@ const LETTERBOX_SWATCHES = [
   { id: 'black', label: 'Black', value: '#000000' },
 ]
 
-function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCancel }) {
+function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCancel, isBusy = false }) {
   return (
     <div className="preset-sizes-screen">
       <div className="screen-header screen-header-column">
@@ -19,6 +19,9 @@ function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCance
       </div>
       <div className="preset-letterbox card">
         <p className="preset-letterbox-label">Letterbox / margins</p>
+        <p className="preset-letterbox-hint">
+          After you pick a platform size, changing margin color updates the main preview automatically.
+        </p>
         <div className="preset-letterbox-row">
           {LETTERBOX_SWATCHES.map(({ id, label, value }) => (
             <button
@@ -26,6 +29,7 @@ function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCance
               type="button"
               className={letterboxColor === value ? 'btn-primary' : 'btn-secondary'}
               onClick={() => onLetterboxColorChange(value)}
+              disabled={isBusy}
             >
               {label}
             </button>
@@ -37,6 +41,7 @@ function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCance
               className="preset-letterbox-color-input"
               value={letterboxColor === 'transparent' ? '#ffffff' : letterboxColor}
               onChange={(e) => onLetterboxColorChange(e.target.value.toLowerCase())}
+              disabled={isBusy}
               aria-label="Custom letterbox color"
             />
           </label>
@@ -49,6 +54,7 @@ function PresetSizes({ letterboxColor, onLetterboxColorChange, onSelect, onCance
             type="button"
             className="btn-primary"
             onClick={() => onSelect({ id, label, width, height })}
+            disabled={isBusy}
           >
             {label} ({width} × {height} px)
           </button>

--- a/front-end/src/hooks/useImageEditingSession.js
+++ b/front-end/src/hooks/useImageEditingSession.js
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getBackendBaseUrl } from '../services/backendMediaClient'
 import {
   addTextToImageFromBackend,
   convertBackendImageResultToLocalMedia,
@@ -25,20 +26,41 @@ const useImageEditingSession = ({
   const [letterboxColor, setLetterboxColor] = useState('transparent')
   const [isExporting, setIsExporting] = useState(false)
   const [exportError, setExportError] = useState(null)
-  const [originalBackendMediaId, setOriginalBackendMediaId] = useState(null)
+  const [sessionNotice, setSessionNotice] = useState(null)
   const [lastCropBoxPx, setLastCropBoxPx] = useState(null)
+
+  /** Media id of the image to letterbox from (never the letterboxed export id). */
+  const presetExportSourceIdRef = useRef(null)
+  const lastPresetExportAtRef = useRef(0)
+  const liveExportRef = useRef({
+    selectedPreset: null,
+    latestExportResult: null,
+    effectiveBackendMediaId: null,
+    previewUrl,
+    sourceUrl,
+    letterboxColor: 'transparent',
+    applyTransformedImage,
+  })
 
   const effectiveBackendResult = latestExportResult?.id ? latestExportResult : backendImageResult
   const effectiveBackendMediaId = effectiveBackendResult?.id || null
   const effectiveImageSrc = previewUrl || effectiveBackendResult?.url || null
 
-  useEffect(() => {
-    if (mediaType !== 'image') return
-    if (originalBackendMediaId) return
-    if (!backendImageResult?.id) return
+  liveExportRef.current = {
+    selectedPreset,
+    latestExportResult,
+    effectiveBackendMediaId,
+    previewUrl,
+    sourceUrl,
+    letterboxColor,
+    applyTransformedImage,
+  }
 
-    setOriginalBackendMediaId(backendImageResult.id)
-  }, [mediaType, originalBackendMediaId, backendImageResult])
+  useEffect(() => {
+    if (!latestExportResult?.id && effectiveBackendMediaId) {
+      presetExportSourceIdRef.current = effectiveBackendMediaId
+    }
+  }, [latestExportResult, effectiveBackendMediaId])
 
   const resetExportSessionState = useCallback(() => {
     setSelectedPreset(null)
@@ -50,16 +72,26 @@ const useImageEditingSession = ({
 
   const resetImageEditingSessionState = useCallback(() => {
     resetExportSessionState()
-    setOriginalBackendMediaId(null)
+    setSessionNotice(null)
     setLastCropBoxPx(null)
   }, [resetExportSessionState])
+
+  /** Clear cached preset export so the next resize/export uses the current pipeline image (#31 sync). */
+  const invalidateLatestExport = useCallback(() => {
+    setLatestExportResult(null)
+    setLastExportLetterbox(null)
+  }, [])
 
   const clearCropSession = useCallback(() => {
     setLastCropBoxPx(null)
   }, [])
 
   const handleSizeSelect = useCallback(async (size) => {
-    if (!effectiveBackendMediaId) {
+    const inputMediaId = latestExportResult?.id
+      ? presetExportSourceIdRef.current
+      : effectiveBackendMediaId
+
+    if (!inputMediaId) {
       setExportError('Image is not ready for backend export yet. Please re-upload and try again.')
       return false
     }
@@ -69,7 +101,7 @@ const useImageEditingSession = ({
       setExportError(null)
 
       const exported = await exportImageFromBackend({
-        mediaId: effectiveBackendMediaId,
+        mediaId: inputMediaId,
         width: size.width,
         height: size.height,
         letterboxColor,
@@ -86,9 +118,12 @@ const useImageEditingSession = ({
       }
 
       applyTransformedImage(file, objectUrl, exported)
+      presetExportSourceIdRef.current = inputMediaId
+      lastPresetExportAtRef.current = Date.now()
       setSelectedPreset(size)
       setLatestExportResult(exported)
       setLastExportLetterbox(letterboxColor)
+      setSessionNotice(null)
       return true
     } catch (err) {
       console.error('Preset export failed:', err)
@@ -97,10 +132,64 @@ const useImageEditingSession = ({
     } finally {
       setIsExporting(false)
     }
-  }, [applyTransformedImage, effectiveBackendMediaId, letterboxColor, previewUrl, sourceUrl])
+  }, [applyTransformedImage, effectiveBackendMediaId, latestExportResult, letterboxColor, previewUrl, sourceUrl])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      if (Date.now() - lastPresetExportAtRef.current < 450) return
+
+      const {
+        selectedPreset: sp,
+        latestExportResult: ler,
+        effectiveBackendMediaId: eid,
+        previewUrl: purl,
+        sourceUrl: surl,
+        letterboxColor: lb,
+        applyTransformedImage: apply,
+      } = liveExportRef.current
+
+      if (!sp?.width) return
+
+      const inputMediaId = ler?.id ? presetExportSourceIdRef.current : eid
+      if (!inputMediaId) return
+
+      void (async () => {
+        try {
+          setIsExporting(true)
+          setExportError(null)
+          const exported = await exportImageFromBackend({
+            mediaId: inputMediaId,
+            width: sp.width,
+            height: sp.height,
+            letterboxColor: lb,
+          })
+          const { file, objectUrl } = await convertBackendImageResultToLocalMedia(exported, {
+            fallbackFileName: 'sticker.png',
+            fallbackMimeType: 'image/png',
+            fetchErrorMessage: 'Failed to load exported image preview.',
+          })
+          if (purl && purl !== surl) {
+            URL.revokeObjectURL(purl)
+          }
+          apply(file, objectUrl, exported)
+          presetExportSourceIdRef.current = inputMediaId
+          lastPresetExportAtRef.current = Date.now()
+          setLatestExportResult(exported)
+          setLastExportLetterbox(lb)
+        } catch (err) {
+          console.error('Preset preview refresh failed:', err)
+          setExportError(err?.message || 'Failed to update preview for letterbox.')
+        } finally {
+          setIsExporting(false)
+        }
+      })()
+    }, 320)
+
+    return () => window.clearTimeout(timer)
+  }, [letterboxColor])
 
   const handleCropApply = useCallback(async (cropRequest) => {
-    const cropSourceMediaId = originalBackendMediaId || effectiveBackendMediaId
+    const cropSourceMediaId = effectiveBackendMediaId
     const ratioCrop = cropRequest?.ratio
 
     if (!cropSourceMediaId) {
@@ -133,15 +222,15 @@ const useImageEditingSession = ({
       })
 
       applyTransformedImage(file, objectUrl, result)
-      setLatestExportResult(null)
-      setLastExportLetterbox(null)
+      resetExportSessionState()
+      setSessionNotice('Platform size cleared — use Resize before Export.')
       setLastCropBoxPx(cropRequest?.pixels || null)
     } catch (err) {
       console.error('Error applying crop in container:', err)
       setExportError('Could not process the cropped image.')
       throw err
     }
-  }, [applyTransformedImage, effectiveBackendMediaId, originalBackendMediaId])
+  }, [applyTransformedImage, effectiveBackendMediaId, resetExportSessionState])
 
   const handleAddTextApply = useCallback(async (textRequest) => {
     if (mediaType !== 'image') return false
@@ -204,7 +293,11 @@ const useImageEditingSession = ({
       setExportError('Please choose a preset size before exporting.')
       return false
     }
-    if (!effectiveBackendMediaId) {
+    const exportInputMediaId = latestExportResult?.id
+      ? presetExportSourceIdRef.current
+      : effectiveBackendMediaId
+
+    if (!exportInputMediaId) {
       setExportError('Image is not ready for backend export yet. Please re-upload and try again.')
       return false
     }
@@ -222,7 +315,7 @@ const useImageEditingSession = ({
         dimsMatch && letterboxMatch
           ? latestExportResult
           : await exportImageFromBackend({
-              mediaId: effectiveBackendMediaId,
+              mediaId: exportInputMediaId,
               width: selectedPreset.width,
               height: selectedPreset.height,
               letterboxColor,
@@ -253,6 +346,35 @@ const useImageEditingSession = ({
     selectedPreset,
   ])
 
+  const resetPresetExportSettings = useCallback(async () => {
+    const restoreId = presetExportSourceIdRef.current
+    resetExportSessionState()
+    setSessionNotice(null)
+    if (!restoreId) return
+    try {
+      setExportError(null)
+      const url = `${getBackendBaseUrl()}/api/media/${restoreId}`
+      const result = {
+        id: restoreId,
+        url,
+        mimeType: 'image/png',
+      }
+      const { file, objectUrl } = await convertBackendImageResultToLocalMedia(result, {
+        fallbackFileName: 'restored.png',
+        fetchErrorMessage: 'Failed to restore image preview.',
+      })
+      if (previewUrl && previewUrl !== sourceUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+      applyTransformedImage(file, objectUrl, result)
+      presetExportSourceIdRef.current = restoreId
+      lastPresetExportAtRef.current = Date.now()
+    } catch (err) {
+      console.error('Reset export settings failed:', err)
+      setExportError(err?.message || 'Could not restore preview after reset.')
+    }
+  }, [applyTransformedImage, previewUrl, resetExportSessionState, sourceUrl])
+
   return {
     selectedPreset,
     latestExportResult,
@@ -261,6 +383,7 @@ const useImageEditingSession = ({
     setLetterboxColor,
     isExporting,
     exportError,
+    sessionNotice,
     lastCropBoxPx,
     effectiveBackendResult,
     effectiveBackendMediaId,
@@ -272,6 +395,8 @@ const useImageEditingSession = ({
     handleCropApply,
     handleAddTextApply,
     handleExport,
+    resetPresetExportSettings,
+    invalidateLatestExport,
   }
 }
 

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -1,6 +1,6 @@
 const DEFAULT_BACKEND_BASE_URL = 'http://localhost:4000'
 
-const getBackendBaseUrl = () =>
+export const getBackendBaseUrl = () =>
   (import.meta.env?.VITE_BACKEND_BASE_URL || DEFAULT_BACKEND_BASE_URL).trim()
 
 const parseErrorMessage = async (response, fallbackMessage = 'Request failed') => {


### PR DESCRIPTION
Closes #31 

- **Crop:** Apply crop to the current backend image (matches preview), not the original upload. Crop UI uses the same image as the main preview.
- **Filters:** After color or preset filters commit, invalidate cached preset export so letterbox/export uses the updated media id.
- **Preset resize:** Track pre-letterbox `mediaId` for exports; refresh preview when letterbox color changes.
- **After crop:** Reset platform size / letterbox selection and show a short notice to use **Resize** again before **Export**.
- **UI:** Main actions ordered **Filters → Crop → Resize**; add **Reset resize**.