### PR TITLE
Tasks#135 and #160/delete confirmation and frontend test

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1165,7 +1165,6 @@ input[type='range']::-moz-range-thumb {
 }
 
 .my-creations-item-meta {
-  margin-top: 0.4rem;
   font-size: 0.85rem;
   color: #666;
 }
@@ -1203,4 +1202,129 @@ input[type='range']::-moz-range-thumb {
 
 .my-creations-item-title--link:hover {
   color: var(--color-link-hover, #003d99);
+}
+
+.my-creations-item-row2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.my-creations-item-row2 .my-creations-item-meta {
+  margin-top: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.my-creations-delete {
+  flex-shrink: 0;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #c4c4d0;
+  background: #fff;
+  color: #8a1a1a;
+  cursor: pointer;
+}
+
+.my-creations-delete:hover {
+  background: #fff5f5;
+  border-color: #c08080;
+}
+
+.my-creations-delete:focus {
+  outline: 2px solid #0057cc;
+  outline-offset: 1px;
+}
+
+.my-creations-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.45);
+  box-sizing: border-box;
+}
+
+.my-creations-modal {
+  width: 100%;
+  max-width: 22rem;
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.25rem 1.25rem 1.1rem;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  border: 1px solid #e0e0e8;
+}
+
+.my-creations-modal-title {
+  margin: 0 0 0.65rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.my-creations-modal-text {
+  margin: 0 0 1rem 0;
+  line-height: 1.45;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.my-creations-modal-quot {
+  font-weight: 600;
+  color: #222;
+  word-break: break-word;
+}
+
+.my-creations-modal-error {
+  margin: 0 0 0.9rem 0;
+  font-size: 0.9rem;
+  color: #9a1a1a;
+}
+
+.my-creations-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.my-creations-modal-btn {
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.45rem 1rem;
+  border-radius: 8px;
+  border: 1px solid #c4c4d0;
+  background: #fff;
+  color: #222;
+  cursor: pointer;
+  min-width: 5.5rem;
+}
+
+.my-creations-modal-btn:hover:not(:disabled) {
+  background: #f3f3f6;
+}
+
+.my-creations-modal-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.my-creations-modal-btn--danger {
+  background: #8a1a1a;
+  border-color: #6f1515;
+  color: #fff;
+}
+
+.my-creations-modal-btn--danger:hover:not(:disabled) {
+  background: #a32222;
 }

--- a/front-end/src/components/MyCreationsPage.jsx
+++ b/front-end/src/components/MyCreationsPage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { fetchCreations } from '../services/creationsApi.js'
+import { useCallback, useEffect, useState } from 'react'
+import { deleteCreation, fetchCreations } from '../services/creationsApi.js'
 import { getCreationKindLabel, getCreationPreviewUrl } from '../utils/creationPreviewUrl.js'
 import { getOrCreateOwnerKey } from '../utils/ownerKey.js'
 
@@ -44,6 +44,9 @@ function MyCreationsPage({ refreshKey = 0, onSelectCreation }) {
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [pendingDelete, setPendingDelete] = useState(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteDialogError, setDeleteDialogError] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -74,6 +77,53 @@ function MyCreationsPage({ refreshKey = 0, onSelectCreation }) {
       cancelled = true
     }
   }, [refreshKey])
+
+  const requestDelete = useCallback((e, row) => {
+    e?.stopPropagation?.()
+    const id = row?._id ?? row?.id
+    if (id == null) return
+    const rawTitle = typeof row?.title === 'string' && row.title.trim() ? row.title.trim() : 'Untitled'
+    setDeleteDialogError(null)
+    setPendingDelete({ id: String(id), title: rawTitle })
+  }, [])
+
+  const cancelDelete = useCallback(
+    (e) => {
+      e?.stopPropagation?.()
+      if (isDeleting) return
+      setPendingDelete(null)
+      setDeleteDialogError(null)
+    },
+    [isDeleting]
+  )
+
+  const confirmDelete = useCallback(async () => {
+    if (!pendingDelete || isDeleting) return
+    setIsDeleting(true)
+    setDeleteDialogError(null)
+    try {
+      await deleteCreation(pendingDelete.id)
+      setItems((prev) => prev.filter((row) => String(row._id ?? row.id) !== pendingDelete.id))
+      setPendingDelete(null)
+    } catch (err) {
+      setDeleteDialogError(err?.message || 'Could not delete.')
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [isDeleting, pendingDelete])
+
+  useEffect(() => {
+    if (!pendingDelete) return undefined
+    const onKey = (e) => {
+      if (e.key === 'Escape' && !isDeleting) {
+        e.preventDefault()
+        setPendingDelete(null)
+        setDeleteDialogError(null)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [pendingDelete, isDeleting])
 
   if (loading) {
     return (
@@ -110,47 +160,104 @@ function MyCreationsPage({ refreshKey = 0, onSelectCreation }) {
           const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : 'Untitled'
           const status = row.status === 'exported' ? 'exported' : 'draft'
           return (
-            <li 
-            key={id} 
-            className={`my-creations-item${onSelectCreation ? ' my-creations-item--clickable' : ''}`}
-            onClick={() => onSelectCreation?.(row)}
-            role={onSelectCreation ? 'button' : undefined}
-            tabIndex={onSelectCreation ? 0 : undefined}
-            onKeyDown={onSelectCreation ? (e) => { if (e.key === 'Enter' || e.key === ' ') onSelectCreation(row) } : undefined}
-            
+            <li
+              key={id}
+              className={`my-creations-item${onSelectCreation ? ' my-creations-item--clickable' : ''}`}
+              onClick={() => onSelectCreation?.(row)}
+              role={onSelectCreation ? 'button' : undefined}
+              tabIndex={onSelectCreation ? 0 : undefined}
+              onKeyDown={
+                onSelectCreation
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') onSelectCreation(row)
+                    }
+                  : undefined
+              }
             >
               <CreationPreviewThumb row={row} title={title} />
               <div className="my-creations-item-body">
                 <div className="my-creations-item-main">
                   {onSelectCreation ? (
                     <button
-                      type='button'
+                      type="button"
                       className="my-creations-item-title my-creations-item-title--link"
                       onClick={(e) => {
                         e.stopPropagation()
                         onSelectCreation(row)
-
                       }}
-                      >
-                        {title}
-                      </button>
-                  ): (
+                    >
+                      {title}
+                    </button>
+                  ) : (
                     <span className="my-creations-item-title">{title}</span>
                   )}
                   <span
                     className={
-                      status === 'exported' ? 'my-creations-badge my-creations-badge--exported' : 'my-creations-badge my-creations-badge--draft'
+                      status === 'exported'
+                        ? 'my-creations-badge my-creations-badge--exported'
+                        : 'my-creations-badge my-creations-badge--draft'
                     }
                   >
                     {status === 'exported' ? 'Exported' : 'Draft'}
                   </span>
                 </div>
-                <div className="my-creations-item-meta">Updated {formatUpdated(row.updatedAt)}</div>
+                <div className="my-creations-item-row2">
+                  <div className="my-creations-item-meta">Updated {formatUpdated(row.updatedAt)}</div>
+                  <button
+                    type="button"
+                    className="my-creations-delete"
+                    onClick={(e) => requestDelete(e, row)}
+                    aria-label={`Delete ${title}`}
+                  >
+                    Delete
+                  </button>
+                </div>
               </div>
             </li>
           )
         })}
       </ul>
+      {pendingDelete ? (
+        <div
+          className="my-creations-modal-backdrop"
+          role="presentation"
+          onClick={cancelDelete}
+        >
+          <div
+            className="my-creations-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="my-creations-delete-heading"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="my-creations-delete-heading" className="my-creations-modal-title">
+              Delete this creation?
+            </h2>
+            <p className="my-creations-modal-text">
+              <span className="my-creations-modal-quot">&ldquo;{pendingDelete.title}&rdquo;</span> will be removed. This
+              cannot be undone.
+            </p>
+            {deleteDialogError ? (
+              <p className="my-creations-modal-error" role="alert">
+                {deleteDialogError}
+              </p>
+            ) : null}
+            <div className="my-creations-modal-actions">
+              <button type="button" className="my-creations-modal-btn" onClick={cancelDelete} disabled={isDeleting}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="my-creations-modal-btn my-creations-modal-btn--danger"
+                onClick={confirmDelete}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -101,6 +101,26 @@ export const getJson = async ({ path, fallbackErrorMessage = 'Request failed' })
   return response.json()
 }
 
+export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed' }) => {
+  const endpoint = `${getBackendBaseUrl()}${path}`
+
+  let response
+  try {
+    response = await fetch(endpoint, { method: 'DELETE' })
+  } catch {
+    throw new Error('Unable to reach backend. Please make sure the backend server is running.')
+  }
+
+  if (!response.ok) {
+    const message = await parseErrorMessage(response, fallbackErrorMessage)
+    const error = new Error(message)
+    error.status = response.status
+    throw error
+  }
+
+  return response.json()
+}
+
 export const patchJson = async ({ path, payload, fallbackErrorMessage = 'Request failed' }) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
 

--- a/front-end/src/services/creationsApi.js
+++ b/front-end/src/services/creationsApi.js
@@ -1,4 +1,4 @@
-import { getJson, patchJson, postJson } from './backendMediaClient.js'
+import { deleteJson, getJson, patchJson, postJson } from './backendMediaClient.js'
 
 const encodeParam = (value) => encodeURIComponent(value)
 
@@ -23,4 +23,10 @@ export const updateCreation = (id, body) =>
     path: `/api/creations/${encodeURIComponent(id)}`,
     payload: body,
     fallbackErrorMessage: 'Could not update creation.',
+  })
+
+export const deleteCreation = (id) =>
+  deleteJson({
+    path: `/api/creations/${encodeURIComponent(id)}`,
+    fallbackErrorMessage: 'Could not delete creation.',
   })

--- a/front-end/test/components/MyCreationsPage.test.jsx
+++ b/front-end/test/components/MyCreationsPage.test.jsx
@@ -1,0 +1,150 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { flushSync } from 'react-dom'
+
+const fetchCreationsMock = vi.fn()
+const deleteCreationMock = vi.fn()
+const getOrCreateOwnerKeyMock = vi.fn(() => 'owner-key-1')
+
+vi.mock('../../src/services/creationsApi.js', () => ({
+  fetchCreations: (...args) => fetchCreationsMock(...args),
+  deleteCreation: (...args) => deleteCreationMock(...args),
+}))
+
+vi.mock('../../src/utils/ownerKey.js', () => ({
+  getOrCreateOwnerKey: (...args) => getOrCreateOwnerKeyMock(...args),
+}))
+
+import MyCreationsPage from '../../src/components/MyCreationsPage.jsx'
+
+const createDeferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const tick = async () => {
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const waitForText = async (container, text, tries = 20) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (container.textContent?.includes(text)) return
+    await tick()
+  }
+  throw new Error(`Timed out waiting for text: ${text}`)
+}
+
+const renderIntoDom = async (element) => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  flushSync(() => {
+    root.render(element)
+  })
+  await tick()
+
+  return {
+    container,
+    cleanup: () => {
+      root.unmount()
+      container.remove()
+    },
+  }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+  fetchCreationsMock.mockReset()
+  deleteCreationMock.mockReset()
+  getOrCreateOwnerKeyMock.mockReset()
+  getOrCreateOwnerKeyMock.mockReturnValue('owner-key-1')
+})
+
+describe('MyCreationsPage', () => {
+  it('shows loading and then renders creations list', async () => {
+    const deferred = createDeferred()
+    fetchCreationsMock.mockReturnValueOnce(deferred.promise)
+
+    const { container, cleanup } = await renderIntoDom(<MyCreationsPage refreshKey={0} />)
+
+    expect(container.textContent).toContain('Loading…')
+    expect(fetchCreationsMock).toHaveBeenCalledWith('owner-key-1')
+
+    deferred.resolve([
+      { _id: 'c-1', title: 'First Draft', status: 'draft', editorPayload: { kind: 'image' }, updatedAt: new Date().toISOString() },
+    ])
+    await waitForText(container, 'First Draft')
+
+    expect(container.textContent).toContain('First Draft')
+    expect(container.textContent).toContain('Draft')
+    cleanup()
+  })
+
+  it('renders error message when fetch fails', async () => {
+    fetchCreationsMock.mockRejectedValueOnce(new Error('Could not load creations.'))
+    const { container, cleanup } = await renderIntoDom(<MyCreationsPage refreshKey={0} />)
+
+    await waitForText(container, 'Could not load creations.')
+    cleanup()
+  })
+
+  it('opens delete dialog and cancels without deleting', async () => {
+    fetchCreationsMock.mockResolvedValueOnce([
+      { _id: 'c-1', title: 'Draft Keep', status: 'draft', editorPayload: { kind: 'image' }, updatedAt: new Date().toISOString() },
+    ])
+
+    const { container, cleanup } = await renderIntoDom(<MyCreationsPage refreshKey={0} />)
+    await waitForText(container, 'Draft Keep')
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Delete')
+    expect(deleteButton).toBeTruthy()
+    deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await tick()
+
+    expect(container.textContent).toContain('Delete this creation?')
+    const cancelButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Cancel')
+    expect(cancelButton).toBeTruthy()
+    cancelButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await tick()
+
+    expect(deleteCreationMock).not.toHaveBeenCalled()
+    expect(container.textContent).not.toContain('Delete this creation?')
+    expect(container.textContent).toContain('Draft Keep')
+    cleanup()
+  })
+
+  it('confirms delete and removes item from the list', async () => {
+    fetchCreationsMock.mockResolvedValueOnce([
+      { _id: 'c-1', title: 'Remove Me', status: 'draft', editorPayload: { kind: 'image' }, updatedAt: new Date().toISOString() },
+    ])
+    deleteCreationMock.mockResolvedValueOnce({ success: true, id: 'c-1' })
+
+    const { container, cleanup } = await renderIntoDom(<MyCreationsPage refreshKey={0} />)
+    await waitForText(container, 'Remove Me')
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Delete')
+    expect(deleteButton).toBeTruthy()
+    deleteButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await tick()
+
+    const confirmButton = container.querySelector('.my-creations-modal .my-creations-modal-btn--danger')
+    expect(confirmButton).toBeTruthy()
+    confirmButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await waitForText(container, 'No saved stickers yet.')
+
+    expect(deleteCreationMock).toHaveBeenCalledWith('c-1')
+    expect(container.textContent).toContain('No saved stickers yet.')
+    expect(container.textContent).not.toContain('Remove Me')
+    cleanup()
+  })
+})

--- a/front-end/test/services/backendMediaClient.test.js
+++ b/front-end/test/services/backendMediaClient.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { postJson, postMultipart } from '../../src/services/backendMediaClient'
+import { deleteJson, postJson, postMultipart } from '../../src/services/backendMediaClient'
 
 describe('backendMediaClient', () => {
   afterEach(() => {
@@ -51,5 +51,19 @@ describe('backendMediaClient', () => {
         fallbackErrorMessage: 'GIF export failed',
       })
     ).rejects.toThrow('Bad request payload')
+  })
+
+  it('calls deleteJson with DELETE and returns JSON on success', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, id: '507f1f77bcf86cd799439011' }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const payload = await deleteJson({ path: '/api/creations/507f1f77bcf86cd799439011' })
+
+    expect(payload).toEqual({ success: true, id: '507f1f77bcf86cd799439011' })
+    const [, options] = mockFetch.mock.calls[0]
+    expect(options.method).toBe('DELETE')
   })
 })


### PR DESCRIPTION
- Implemented My Creations delete flow with confirmation modal in the frontend.
- Wired delete API client (`deleteJson` / `deleteCreation`) and removed deleted items from UI state immediately.
- Added frontend tests for My Creations loading/error/list states and delete confirm/cancel behavior.

- [x] `cd front-end && npm test -- --run`
- [x] Manual check: open My Creations, click **Delete**, confirm removes item.
- [x] Manual check: click **Cancel** (or dismiss) keeps data unchanged.

- Closes #135 
- Closes #160 