### PR TITLE
feat: persist creation on export with status=exported

### DIFF
--- a/front-end/src/components/image/ImageEditorFlow.jsx
+++ b/front-end/src/components/image/ImageEditorFlow.jsx
@@ -190,7 +190,34 @@ function ImageEditorFlow({ imageSession, media, draft, textOverlay, onBack, onDr
       onBack={onBack}
       onOpenFilters={handleOpenFilters}
       onSize={handleOpenSizes}
-      onExport={handleExport}
+      onExport={async () => {
+        const success = await handleExport()
+        if (success) {
+          try {
+            if (activeDraftId) {
+              await updateCreation(activeDraftId, { status: 'exported' })
+            } else {
+              const result = await createCreation({
+                ownerKey: getOrCreateOwnerKey(),
+                title: defaultCreationTitle(selectedMedia),
+                editorPayload: buildImageCreationPayload({
+                  backendMediaId: effectiveBackendMediaId,
+                  lastCropBoxPx,
+                  colorAdjustments,
+                  selectedImageFilterPreset,
+                  selectedPreset,
+                  letterboxColor,
+                }),
+                status: 'exported',
+              })
+              const id = result?._id ?? result?.id
+              if (id) onActiveDraftSaved(String(id), null)
+            }
+          } catch (err) {
+            console.warn('Could not persist export status:', err)
+          }
+        }
+      }}
       onSaveForLater={handleSaveForLaterImage}
       isSavingDraft={isSavingDraft}
       saveDraftError={saveForLaterError}


### PR DESCRIPTION
Export action now writes creation record to DB with status=exported. If no draft exists, creates a new creation record on export.

Closes #132 