### PR TITLE
User stories #5 and #6/task#156/signup signin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Ensure you have Node.js and npm installed
 
 - Open the app in your browser by navigating to: `http://localhost:5173/`
 
-### Run Unit Tests (Mocha + Chai)
+### Run unit tests
 
-- Run: `npm test` in `back-end`
+- **Back-end** (Mocha + Chai): from the `back-end` directory, run `npm test`.
+- **Front-end** (Vitest): from the repository root, run `cd front-end && npm test -- --run` (use `--run` for a single non-watch run, e.g. in CI or before pushing).
 
 ### Check Back-End Coverage (c8)
 

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -23,9 +23,13 @@ Front-end tests are organized under a single top-level folder:
 
 This mirrors the back-end convention (`back-end/test/**`) for consistent project structure.
 
-Run the front-end unit tests:
+Run the front-end unit tests (single run, exits when finished):
 
-- `npm test`
+- `npm test -- --run`
+
+From the repository root:
+
+- `cd front-end && npm test -- --run`
 
 Run in watch mode while developing:
 

--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1602,6 +1602,29 @@ input[type='range']::-moz-range-thumb {
   border-radius: 4px;
 }
 
+.auth-dev-guest-btn {
+  margin-top: 0.25rem;
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.35rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-family: inherit;
+}
+
+.auth-dev-guest-btn:hover {
+  color: #555;
+}
+
+.auth-dev-guest-btn:focus-visible {
+  outline: 2px solid rgba(100, 108, 255, 0.35);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .auth-card {
   width: 100%;
   max-width: 360px;

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,11 +1,20 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import './App.css'
+import {
+  clearAuthToken,
+  clearDevGuestSession,
+  DEV_GUEST_PROFILE,
+  getAuthToken,
+  isDevGuestSession,
+  setDevGuestSession,
+} from './auth/authSession.js'
 import AuthLanding from './components/AuthLanding'
 import EditorContainer from './components/EditorContainer'
 import HomeView from './components/HomeView'
 import MyCreationsPage from './components/MyCreationsPage'
 import SignInPage from './components/SignInPage'
 import SignUpPage from './components/SignUpPage'
+import * as authApi from './services/authApi.js'
 
 const APP_SCREENS = {
   LANDING: 'landing',
@@ -21,23 +30,84 @@ const APP_VIEWS = {
 }
 
 function App() {
-  const [appScreen, setAppScreen] = useState(APP_SCREENS.LANDING)
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [appScreen, setAppScreen] = useState(() =>
+    getAuthToken() || isDevGuestSession() ? APP_SCREENS.APP : APP_SCREENS.LANDING
+  )
+  const [isAuthenticated, setIsAuthenticated] = useState(() =>
+    getAuthToken() ? false : Boolean(isDevGuestSession())
+  )
+  const [currentUser, setCurrentUser] = useState(() =>
+    isDevGuestSession() && !getAuthToken() ? DEV_GUEST_PROFILE : null
+  )
   const [activeView, setActiveView] = useState(APP_VIEWS.HOME)
   const [creationsRefreshKey, setCreationsRefreshKey] = useState(0)
   const loadDraftRef = useRef(null)
+
+  useEffect(() => {
+    const onExpire = () => {
+      clearDevGuestSession()
+      setCurrentUser(null)
+      setIsAuthenticated(false)
+      setAppScreen(APP_SCREENS.SIGN_IN)
+    }
+    window.addEventListener('auth:session-expired', onExpire)
+    return () => window.removeEventListener('auth:session-expired', onExpire)
+  }, [])
+
+  useEffect(() => {
+    if (!getAuthToken()) return undefined
+    let cancelled = false
+    ;(async () => {
+      try {
+        const user = await authApi.fetchCurrentUser()
+        if (cancelled) return
+        setCurrentUser(user)
+        setIsAuthenticated(true)
+        setAppScreen(APP_SCREENS.APP)
+        clearDevGuestSession()
+      } catch {
+        if (!cancelled) {
+          clearAuthToken()
+          setIsAuthenticated(false)
+          setCurrentUser(null)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleSelectCreation = useCallback((creation) => {
     setActiveView(APP_VIEWS.CREATE)
     setTimeout(() => loadDraftRef.current?.(creation), 0)
   }, [])
 
+  const showDevGuestEntry =
+    import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_GUEST === 'true'
+
   if (appScreen === APP_SCREENS.LANDING) {
     return (
       <AuthLanding
         onSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
         onSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
-        onGuest={() => setAppScreen(APP_SCREENS.APP)}
+        onGuest={() => {
+          clearAuthToken()
+          clearDevGuestSession()
+          setCurrentUser(null)
+          setIsAuthenticated(false)
+          setAppScreen(APP_SCREENS.APP)
+        }}
+        onDevGuest={
+          showDevGuestEntry
+            ? () => {
+                setDevGuestSession()
+                setCurrentUser(DEV_GUEST_PROFILE)
+                setIsAuthenticated(true)
+                setAppScreen(APP_SCREENS.APP)
+              }
+            : undefined
+        }
       />
     )
   }
@@ -45,7 +115,11 @@ function App() {
   if (appScreen === APP_SCREENS.SIGN_IN) {
     return (
       <SignInPage
-        onSignIn={() => { setIsAuthenticated(true); setAppScreen(APP_SCREENS.APP) }}
+        onSuccess={(user) => {
+          setCurrentUser(user)
+          setIsAuthenticated(true)
+          setAppScreen(APP_SCREENS.APP)
+        }}
         onBack={() => setAppScreen(APP_SCREENS.LANDING)}
         onGoSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
       />
@@ -55,7 +129,11 @@ function App() {
   if (appScreen === APP_SCREENS.SIGN_UP) {
     return (
       <SignUpPage
-        onSignUp={() => { setIsAuthenticated(true); setAppScreen(APP_SCREENS.APP) }}
+        onSuccess={(user) => {
+          setCurrentUser(user)
+          setIsAuthenticated(true)
+          setAppScreen(APP_SCREENS.APP)
+        }}
         onBack={() => setAppScreen(APP_SCREENS.LANDING)}
         onGoSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
       />
@@ -80,9 +158,15 @@ function App() {
           refreshKey={creationsRefreshKey}
           onSelectCreation={handleSelectCreation}
           isAuthenticated={isAuthenticated}
+          currentUser={currentUser}
           onGoSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
           onGoSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
-          onSignOut={() => { setIsAuthenticated(false); setAppScreen(APP_SCREENS.LANDING) }}
+          onSignOut={() => {
+            authApi.logoutSession()
+            setCurrentUser(null)
+            setIsAuthenticated(false)
+            setAppScreen(APP_SCREENS.LANDING)
+          }}
         />
       )
     }

--- a/front-end/src/auth/authSession.js
+++ b/front-end/src/auth/authSession.js
@@ -1,0 +1,53 @@
+const STORAGE_KEY = 'stickercreate_auth_token'
+const DEV_GUEST_KEY = 'stickercreate_dev_guest'
+
+export const DEV_GUEST_PROFILE = {
+  email: 'guest@local.dev',
+  displayName: 'Dev Guest',
+  bio: 'No server account; drafts use this browser ownerKey.',
+}
+
+export const getAuthToken = () => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return v && typeof v === 'string' ? v.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+export const setAuthToken = (token) => {
+  try {
+    if (token && typeof token === 'string') {
+      localStorage.setItem(STORAGE_KEY, token.trim())
+      localStorage.removeItem(DEV_GUEST_KEY)
+    }
+  } catch {}
+}
+
+export const clearAuthToken = () => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {}
+}
+
+export const setDevGuestSession = () => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+    localStorage.setItem(DEV_GUEST_KEY, '1')
+  } catch {}
+}
+
+export const clearDevGuestSession = () => {
+  try {
+    localStorage.removeItem(DEV_GUEST_KEY)
+  } catch {}
+}
+
+export const isDevGuestSession = () => {
+  try {
+    return localStorage.getItem(DEV_GUEST_KEY) === '1' && !getAuthToken()
+  } catch {
+    return false
+  }
+}

--- a/front-end/src/auth/authSession.js
+++ b/front-end/src/auth/authSession.js
@@ -22,26 +22,34 @@ export const setAuthToken = (token) => {
       localStorage.setItem(STORAGE_KEY, token.trim())
       localStorage.removeItem(DEV_GUEST_KEY)
     }
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const clearAuthToken = () => {
   try {
     localStorage.removeItem(STORAGE_KEY)
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const setDevGuestSession = () => {
   try {
     localStorage.removeItem(STORAGE_KEY)
     localStorage.setItem(DEV_GUEST_KEY, '1')
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const clearDevGuestSession = () => {
   try {
     localStorage.removeItem(DEV_GUEST_KEY)
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const isDevGuestSession = () => {

--- a/front-end/src/components/AuthLanding.jsx
+++ b/front-end/src/components/AuthLanding.jsx
@@ -1,4 +1,4 @@
-function AuthLanding({ onSignIn, onSignUp, onGuest }) {
+function AuthLanding({ onSignIn, onSignUp, onGuest, onDevGuest }) {
   return (
     <div className="auth-screen">
       <div className="auth-landing-brand">
@@ -15,6 +15,11 @@ function AuthLanding({ onSignIn, onSignUp, onGuest }) {
         <button type="button" className="auth-guest-btn" onClick={onGuest}>
           Continue as Guest
         </button>
+        {onDevGuest ? (
+          <button type="button" className="auth-dev-guest-btn" onClick={onDevGuest}>
+            Dev session (no backend login)
+          </button>
+        ) : null}
       </div>
     </div>
   )

--- a/front-end/src/components/MyCreationsPage.jsx
+++ b/front-end/src/components/MyCreationsPage.jsx
@@ -59,6 +59,32 @@ const formatUpdated = (iso) => {
   }
 }
 
+const profileDisplayName = (user) => {
+  const d = user?.displayName?.trim()
+  if (d) return d
+  const e = user?.email?.trim()
+  if (e) return e
+  return 'Your Name'
+}
+
+const profileBioText = (user) => {
+  const b = user?.bio?.trim()
+  if (b) return b
+  return 'No bio yet.'
+}
+
+const profileInitials = (user) => {
+  const dn = user?.displayName?.trim()
+  if (dn) {
+    const parts = dn.split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase().slice(0, 2)
+    if (parts[0]) return parts[0].slice(0, 2).toUpperCase()
+  }
+  const em = user?.email?.trim()
+  if (em) return em.slice(0, 2).toUpperCase()
+  return 'SC'
+}
+
 function GuestProfileView({ onGoSignIn, onGoSignUp }) {
   return (
     <div className="profile-guest">
@@ -91,6 +117,7 @@ function MyCreationsPage({
   refreshKey = 0,
   onSelectCreation,
   isAuthenticated = true,
+  currentUser = null,
   onGoSignIn,
   onGoSignUp,
   onSignOut,
@@ -458,11 +485,11 @@ function MyCreationsPage({
     <div className="profile-page" role="region" aria-label="Profile">
       <div className="profile-header">
         <div className="profile-avatar" aria-hidden="true">
-          <span className="profile-avatar-initials">SC</span>
+          <span className="profile-avatar-initials">{profileInitials(currentUser)}</span>
         </div>
 
-        <p className="profile-name">Your Name</p>
-        <p className="profile-bio">No bio yet.</p>
+        <p className="profile-name">{profileDisplayName(currentUser)}</p>
+        <p className="profile-bio">{profileBioText(currentUser)}</p>
 
         <div className="profile-socials">
           <button type="button" className="profile-social-link">

--- a/front-end/src/components/SignInPage.jsx
+++ b/front-end/src/components/SignInPage.jsx
@@ -1,12 +1,24 @@
 import { useState } from 'react'
+import * as authApi from '../services/authApi.js'
 
-function SignInPage({ onSignIn, onBack, onGoSignUp }) {
+function SignInPage({ onSuccess, onBack, onGoSignUp }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    onSignIn()
+    setError('')
+    setSubmitting(true)
+    try {
+      const user = await authApi.login({ email, password })
+      onSuccess(user)
+    } catch (err) {
+      setError(err?.message || 'Sign in failed')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -16,6 +28,11 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
           ← Back
         </button>
         <h2 className="auth-card-title">Sign In</h2>
+        {error ? (
+          <p className="editor-status editor-status--error" role="alert">
+            {error}
+          </p>
+        ) : null}
         <form className="auth-form" onSubmit={handleSubmit}>
           <div className="auth-field">
             <label htmlFor="signin-email" className="auth-label">
@@ -29,6 +46,7 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              required
             />
           </div>
           <div className="auth-field">
@@ -43,10 +61,11 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
               autoComplete="current-password"
+              required
             />
           </div>
-          <button type="submit" className="btn-primary auth-action-btn">
-            Sign In
+          <button type="submit" className="btn-primary auth-action-btn" disabled={submitting}>
+            {submitting ? 'Signing in…' : 'Sign In'}
           </button>
         </form>
         <p className="auth-switch-text">

--- a/front-end/src/components/SignUpPage.jsx
+++ b/front-end/src/components/SignUpPage.jsx
@@ -1,13 +1,29 @@
 import { useState } from 'react'
+import * as authApi from '../services/authApi.js'
 
-function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
+function SignUpPage({ onSuccess, onBack, onGoSignIn }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    onSignUp()
+    setError('')
+    if (password !== confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const user = await authApi.register({ email, password })
+      onSuccess(user)
+    } catch (err) {
+      setError(err?.message || 'Registration failed')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -17,6 +33,11 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
           ← Back
         </button>
         <h2 className="auth-card-title">Sign Up</h2>
+        {error ? (
+          <p className="editor-status editor-status--error" role="alert">
+            {error}
+          </p>
+        ) : null}
         <form className="auth-form" onSubmit={handleSubmit}>
           <div className="auth-field">
             <label htmlFor="signup-email" className="auth-label">
@@ -30,6 +51,7 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              required
             />
           </div>
           <div className="auth-field">
@@ -44,6 +66,7 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
               autoComplete="new-password"
+              required
             />
           </div>
           <div className="auth-field">
@@ -58,10 +81,11 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setConfirm(e.target.value)}
               placeholder="••••••••"
               autoComplete="new-password"
+              required
             />
           </div>
-          <button type="submit" className="btn-primary auth-action-btn">
-            Create Account
+          <button type="submit" className="btn-primary auth-action-btn" disabled={submitting}>
+            {submitting ? 'Creating…' : 'Create Account'}
           </button>
         </form>
         <p className="auth-switch-text">

--- a/front-end/src/services/authApi.js
+++ b/front-end/src/services/authApi.js
@@ -1,0 +1,41 @@
+import { getJson, postJson } from './backendMediaClient.js'
+import { clearAuthToken, clearDevGuestSession, getAuthToken, setAuthToken } from '../auth/authSession.js'
+
+const pickToken = (body) =>
+  (body && typeof body === 'object' && (body.token || body.accessToken)) || ''
+
+export const register = async ({ email, password }) => {
+  const body = await postJson({
+    path: '/api/auth/register',
+    payload: { email, password },
+    skipAuth: true,
+    fallbackErrorMessage: 'Registration failed',
+  })
+  const token = pickToken(body)
+  if (!token) throw new Error('Invalid server response')
+  setAuthToken(token)
+  return fetchCurrentUser()
+}
+
+export const login = async ({ email, password }) => {
+  const body = await postJson({
+    path: '/api/auth/login',
+    payload: { email, password },
+    skipAuth: true,
+    fallbackErrorMessage: 'Sign in failed',
+  })
+  const token = pickToken(body)
+  if (!token) throw new Error('Invalid server response')
+  setAuthToken(token)
+  return fetchCurrentUser()
+}
+
+export const fetchCurrentUser = async () => {
+  if (!getAuthToken()) return null
+  return getJson({ path: '/api/me', fallbackErrorMessage: 'Could not load account' })
+}
+
+export const logoutSession = () => {
+  clearAuthToken()
+  clearDevGuestSession()
+}

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -22,7 +22,9 @@ const parseErrorMessage = async (response, fallbackMessage = 'Request failed') =
       if (parts.length) return parts.join(' ')
     }
     if (typeof payload?.message === 'string') return payload.message
-  } catch {}
+  } catch {
+    void 0
+  }
 
   return `${fallbackMessage} (${response.status})`
 }

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -1,15 +1,28 @@
+import { clearAuthToken, getAuthToken } from '../auth/authSession.js'
+
 const DEFAULT_BACKEND_BASE_URL = 'http://localhost:4000'
 
 export const getBackendBaseUrl = () =>
   (import.meta.env?.VITE_BACKEND_BASE_URL || DEFAULT_BACKEND_BASE_URL).trim()
 
+const notifyUnauthorized = (skipAuth, hadBearer, status) => {
+  if (status !== 401 || skipAuth || !hadBearer) return
+  clearAuthToken()
+  window.dispatchEvent(new CustomEvent('auth:session-expired'))
+}
+
 const parseErrorMessage = async (response, fallbackMessage = 'Request failed') => {
   try {
     const payload = await response.json()
-    if (payload?.error) return payload.error
-  } catch {
-    // ignore JSON parse errors
-  }
+    if (typeof payload?.error === 'string') return payload.error
+    if (Array.isArray(payload?.errors) && payload.errors.length) {
+      const parts = payload.errors
+        .map((e) => (typeof e === 'string' ? e : e.msg || e.message))
+        .filter(Boolean)
+      if (parts.length) return parts.join(' ')
+    }
+    if (typeof payload?.message === 'string') return payload.message
+  } catch {}
 
   return `${fallbackMessage} (${response.status})`
 }
@@ -20,6 +33,7 @@ export const postMultipart = async ({
   file,
   fields,
   fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
 }) => {
   if (!file) {
     throw new Error('No file provided')
@@ -36,11 +50,15 @@ export const postMultipart = async ({
   }
 
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'POST',
+      headers,
       body: formData,
     })
   } catch {
@@ -48,6 +66,7 @@ export const postMultipart = async ({
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -57,14 +76,22 @@ export const postMultipart = async ({
   return response.json()
 }
 
-export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request failed' }) => {
+export const postJson = async ({
+  path,
+  payload,
+  fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
+}) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = { 'Content-Type': 'application/json' }
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(payload ?? {}),
     })
   } catch {
@@ -72,6 +99,7 @@ export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request 
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -81,17 +109,21 @@ export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request 
   return response.json()
 }
 
-export const getJson = async ({ path, fallbackErrorMessage = 'Request failed' }) => {
+export const getJson = async ({ path, fallbackErrorMessage = 'Request failed', skipAuth = false }) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
-    response = await fetch(endpoint, { method: 'GET' })
+    response = await fetch(endpoint, { method: 'GET', headers })
   } catch {
     throw new Error('Unable to reach backend. Please make sure the backend server is running.')
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -101,17 +133,21 @@ export const getJson = async ({ path, fallbackErrorMessage = 'Request failed' })
   return response.json()
 }
 
-export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed' }) => {
+export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed', skipAuth = false }) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
-    response = await fetch(endpoint, { method: 'DELETE' })
+    response = await fetch(endpoint, { method: 'DELETE', headers })
   } catch {
     throw new Error('Unable to reach backend. Please make sure the backend server is running.')
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -121,14 +157,22 @@ export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed'
   return response.json()
 }
 
-export const patchJson = async ({ path, payload, fallbackErrorMessage = 'Request failed' }) => {
+export const patchJson = async ({
+  path,
+  payload,
+  fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
+}) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = { 'Content-Type': 'application/json' }
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(payload ?? {}),
     })
   } catch {
@@ -136,6 +180,7 @@ export const patchJson = async ({ path, payload, fallbackErrorMessage = 'Request
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status


### PR DESCRIPTION
## Summary
Closes #156 (US #5 / #6): sign-in and sign-up call `POST /api/auth/login` and `POST /api/auth/register`, persist JWT in `localStorage`, attach `Authorization: Bearer` on API requests, handle 401 by clearing the session, and load identity from `GET /api/me`. Adds an optional **dev guest session** (dev / `VITE_ENABLE_DEV_GUEST`) so local work can continue before #155 lands.

## Test plan
- [x] `cd back-end && npm test`
- [x] `cd front-end && npm test -- --run`
- [x] Manual: dev guest → Profile shows guest user; creations still use `ownerKey`
- [x] Manual: real sign-in/up after #155 merges

## Notes
- Backend routes from #155 are not included; sign-in/up may show `Route not found` until the API exists.