### PR TITLE
Tasks#155 and #169/jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Ensure you have Node.js and npm installed
 
 - Open the app in your browser by navigating to: `http://localhost:5173/`
 
-### Run Unit Tests (Mocha + Chai)
+### Run unit tests
 
-- Run: `npm test` in `back-end`
+- **Back-end** (Mocha + Chai): from the `back-end` directory, run `npm test`.
+- **Front-end** (Vitest): from the repository root, run `cd front-end && npm test -- --run` (use `--run` for a single non-watch run, e.g. in CI or before pushing).
 
 ### Check Back-End Coverage (c8)
 

--- a/back-end/.env.example
+++ b/back-end/.env.example
@@ -1,0 +1,6 @@
+MONGODB_URI=mongodb+srv://USER:PASSWORD@cluster.mongodb.net/?retryWrites=true&w=majority
+MONGODB_DB_NAME=stereoscopically
+JWT_SECRET=replace-with-a-long-random-secret-minimum-32-chars
+JWT_EXPIRES_IN=7d
+BCRYPT_COST=11
+PORT=4000

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -9,11 +9,13 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@ffmpeg-installer/ffmpeg": "^1.1.0",
+				"bcrypt": "^6.0.0",
 				"cors": "^2.8.5",
 				"dotenv": "^17.4.2",
 				"express": "^4.21.2",
 				"express-validator": "^7.3.2",
 				"fluent-ffmpeg": "^2.1.3",
+				"jsonwebtoken": "^9.0.3",
 				"mongoose": "^9.4.1",
 				"multer": "^1.4.5-lts.2",
 				"sharp": "^0.34.5"
@@ -844,6 +846,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bcrypt": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+			"integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^8.3.0",
+				"node-gyp-build": "^4.8.4"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/body-parser": {
 			"version": "1.20.4",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -893,6 +909,12 @@
 			"engines": {
 				"node": ">=20.19.0"
 			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
@@ -1392,6 +1414,15 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -2021,6 +2052,55 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"node_modules/kareem": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-3.2.0.tgz",
@@ -2050,6 +2130,48 @@
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"license": "MIT"
 		},
 		"node_modules/log-symbols": {
@@ -2428,6 +2550,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+			"integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
 			}
 		},
 		"node_modules/object-assign": {

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -7,19 +7,21 @@
 	"scripts": {
 		"start": "node server.js",
 		"dev": "node server.js",
-		"test": "mocha \"test/**/*.test.js\"",
-		"coverage": "c8 --all --src . --reporter=text --reporter=html mocha \"test/**/*.test.js\""
+		"test": "mocha \"test/**/*.test.js\" --exit",
+		"coverage": "c8 --all --src . --reporter=text --reporter=html mocha \"test/**/*.test.js\" --exit"
 	},
 	"overrides": {
 		"serialize-javascript": "^7.0.5"
 	},
 	"dependencies": {
 		"@ffmpeg-installer/ffmpeg": "^1.1.0",
+		"bcrypt": "^6.0.0",
 		"cors": "^2.8.5",
 		"dotenv": "^17.4.2",
 		"express": "^4.21.2",
 		"express-validator": "^7.3.2",
 		"fluent-ffmpeg": "^2.1.3",
+		"jsonwebtoken": "^9.0.3",
 		"mongoose": "^9.4.1",
 		"multer": "^1.4.5-lts.2",
 		"sharp": "^0.34.5"

--- a/back-end/readme.md
+++ b/back-end/readme.md
@@ -11,6 +11,7 @@ This backend provides image-processing endpoints for the StickerCreate app. It i
 - Multer (multipart upload handling)
 - Sharp (image processing)
 - Fluent-ffmpeg + @ffmpeg-installer/ffmpeg (video trim/filter processing)
+- Mongoose Models for app data and JWT auth flows
 
 ## Setup
 
@@ -19,7 +20,20 @@ npm install
 cp .env.example .env
 ```
 
-Configure `.env` with your MongoDB Atlas credentials before running the server.
+Configure `.env` from `.env.example` with your MongoDB Atlas URI (`MONGODB_URI`) and auth secret (`JWT_SECRET`) before running the server.
+
+### Authentication compliance (JWT + validation)
+
+The database sprint requires JWT-based authorization, secrets in `.env` (never committed), and validating incoming body fields before persisting to MongoDB via Mongoose:
+
+- Registration and login use **bcrypt-hashed passwords** (`passwordHash` in the DB; plaintext passwords never stored).
+- Successful **register/signup** or **login/signin** returns a JWT signed with **HS256**, configured via `JWT_SECRET` with expiry `JWT_EXPIRES_IN` (default `7d`).
+- Protected routes validate the bearer token middleware-side; **`GET /api/me`** resolves the authenticated user document.
+- `express-validator` runs on auth JSON bodies prior to Mongoose reads/writes; validation failures return **`400`** with an `errors` array.
+
+Aliases for the same handlers: **`POST /api/auth/register`** and **`POST /api/auth/signup`**; **`POST /api/auth/login`** and **`POST /api/auth/signin`**.
+
+Integration tests under `test/auth.routes.test.js` run only when **`MONGODB_URI`** and **`JWT_SECRET`** are set in the environment (same as other Atlas-backed route tests).
 
 ## Scripts
 
@@ -43,6 +57,54 @@ Default server URL: `http://localhost:4000`
 {
   "status": "ok",
   "database": "connected"
+}
+```
+
+### Register / sign-up
+
+- **Methods:** `POST`
+- **Paths:** `/api/auth/register`, `/api/auth/signup`
+
+**JSON body**
+
+- `email` (required string, normalized and validated).
+- `password` (required string, 8–128 characters).
+- `displayName`, `bio`, `avatarUrl` (optional strings; `avatarUrl` must use `http:` or `https:` when supplied).
+
+Success **`201`** response:
+
+```json
+{
+  "token": "<jwt>"
+}
+```
+
+Duplicate email **`409`** with `{ "error": "Email already in use." }`.
+
+### Login / sign-in
+
+- **Methods:** `POST`
+- **Paths:** `/api/auth/login`, `/api/auth/signin`
+
+**JSON body**: `email`, `password`
+
+Success **`200`**: `{ "token": "<jwt>" }`. Wrong credential **`401`**: `{ "error": "Invalid credentials." }`.
+
+### Current account
+
+- **Method:** `GET`
+- **Path:** `/api/me`
+- **Headers:** `Authorization: Bearer <jwt>`
+
+**Success `200`**
+
+```json
+{
+  "id": "...",
+  "email": "...",
+  "displayName": "",
+  "avatarUrl": "",
+  "bio": ""
 }
 ```
 

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url'
 import { PORT } from './src/config/constants.js'
 import { connectToDatabase } from './src/config/database.js'
 import { errorHandler, notFoundHandler } from './src/middleware/errorMiddleware.js'
+import authRoutes from './src/routes/authRoutes.js'
 import mediaRoutes from './src/routes/mediaRoutes.js'
 import creationRoutes from './src/routes/creationRoutes.js'
 
@@ -13,6 +14,7 @@ const app = express()
 
 app.use(cors())
 app.use(express.json())
+app.use(authRoutes)
 app.use(mediaRoutes)
 app.use(creationRoutes) 
 app.use(notFoundHandler)

--- a/back-end/src/config/constants.js
+++ b/back-end/src/config/constants.js
@@ -1,4 +1,8 @@
 export const PORT = process.env.PORT || 4000
+export const BCRYPT_COST =
+	typeof process.env.BCRYPT_COST !== 'undefined' && Number.isFinite(Number(process.env.BCRYPT_COST))
+		? Math.min(14, Math.max(10, Number(process.env.BCRYPT_COST)))
+		: 11
 export const MAX_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024
 export const MAX_EXPORT_DIMENSION = 4096
 export const MEDIA_TTL_MS = 10 * 60 * 1000

--- a/back-end/src/controllers/authController.js
+++ b/back-end/src/controllers/authController.js
@@ -1,0 +1,106 @@
+import bcrypt from 'bcrypt'
+import jwt from 'jsonwebtoken'
+import mongoose from 'mongoose'
+
+import { BCRYPT_COST } from '../config/constants.js'
+import { User } from '../models/userModel.js'
+
+const getJwtExpiresIn = () => process.env.JWT_EXPIRES_IN || '7d'
+
+const tokenForUser = (userDoc) =>
+	jwt.sign({ sub: userDoc._id.toString() }, process.env.JWT_SECRET, {
+		expiresIn: getJwtExpiresIn(),
+	})
+
+const defaultDisplayName = (emailLower) => {
+	const local = typeof emailLower === 'string' ? emailLower.split('@')[0] : ''
+	return local && local.trim() ? local.trim().slice(0, 100) : 'Sticker fan'
+}
+
+export const register = async (req, res) => {
+	if (!process.env.JWT_SECRET) {
+		return res.status(500).json({ error: 'Server JWT configuration missing.' })
+	}
+
+	const { email, password, displayName: rawName, bio, avatarUrl } = req.body
+
+	const trimmedEmail = typeof email === 'string' ? email.trim().toLowerCase() : ''
+	let displayName = typeof rawName === 'string' && rawName.trim() ? rawName.trim().slice(0, 100) : ''
+	displayName = displayName || defaultDisplayName(trimmedEmail)
+
+	const trimmedBio = typeof bio === 'string' ? bio.trim().slice(0, 500) : ''
+	const trimmedAvatar =
+		typeof avatarUrl === 'string' && avatarUrl.trim()
+			? avatarUrl.trim().slice(0, 2048)
+			: ''
+
+	let passwordHash
+	try {
+		passwordHash = await bcrypt.hash(password, BCRYPT_COST)
+	} catch {
+		return res.status(500).json({ error: 'Could not secure password.' })
+	}
+
+	try {
+		const userDoc = await User.create({
+			email: trimmedEmail,
+			passwordHash,
+			displayName,
+			bio: trimmedBio,
+			avatarUrl: trimmedAvatar,
+		})
+
+		const token = tokenForUser(userDoc)
+		return res.status(201).json({ token })
+	} catch (err) {
+		if (err instanceof mongoose.Error.ValidationError) {
+			return res.status(400).json({
+				error: 'Invalid registration data.',
+			})
+		}
+		if (err.code === 11000) {
+			return res.status(409).json({ error: 'Email already in use.' })
+		}
+		console.error('register error:', err)
+		return res.status(500).json({ error: 'Registration failed.' })
+	}
+}
+
+export const login = async (req, res) => {
+	if (!process.env.JWT_SECRET) {
+		return res.status(500).json({ error: 'Server JWT configuration missing.' })
+	}
+
+	const email = typeof req.body.email === 'string' ? req.body.email.trim().toLowerCase() : ''
+	const password = req.body.password
+
+	try {
+		const userDoc = await User.findOne({ email })
+		const ok = userDoc && (await bcrypt.compare(password, userDoc.passwordHash))
+
+		if (!ok) {
+			return res.status(401).json({ error: 'Invalid credentials.' })
+		}
+
+		const token = tokenForUser(userDoc)
+		return res.status(200).json({ token })
+	} catch (err) {
+		console.error('login error:', err)
+		return res.status(500).json({ error: 'Sign-in failed.' })
+	}
+}
+
+export const me = async (req, res) => {
+	const doc = req.authUserDoc
+	if (!doc) {
+		return res.status(401).json({ error: 'Authentication required.' })
+	}
+
+	return res.status(200).json({
+		id: doc._id.toString(),
+		email: doc.email,
+		displayName: doc.displayName ?? '',
+		avatarUrl: doc.avatarUrl ?? '',
+		bio: doc.bio ?? '',
+	})
+}

--- a/back-end/src/middleware/authMiddleware.js
+++ b/back-end/src/middleware/authMiddleware.js
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken'
+
+import { User } from '../models/userModel.js'
+
+export const requireAuth = async (req, res, next) => {
+	const header = req.headers.authorization || ''
+	const parts = header.split(' ')
+	if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer' || !parts[1]?.trim()) {
+		return res.status(401).json({ error: 'Authentication required.' })
+	}
+
+	const token = parts[1].trim()
+
+	if (!process.env.JWT_SECRET) {
+		return res.status(500).json({ error: 'Server JWT configuration missing.' })
+	}
+
+	try {
+		const payload = jwt.verify(token, process.env.JWT_SECRET)
+		const userId =
+			payload && typeof payload.sub === 'string'
+				? payload.sub.trim()
+				: payload && typeof payload.userId === 'string'
+					? payload.userId.trim()
+					: ''
+
+		if (!userId) {
+			return res.status(401).json({ error: 'Invalid token.' })
+		}
+
+		const userDoc = await User.findById(userId).select('-passwordHash').exec()
+		if (!userDoc) {
+			return res.status(401).json({ error: 'Invalid token.' })
+		}
+
+		req.authUserId = userId
+		req.authUserDoc = userDoc
+		next()
+	} catch {
+		return res.status(401).json({ error: 'Invalid or expired token.' })
+	}
+}

--- a/back-end/src/middleware/validateRequest.js
+++ b/back-end/src/middleware/validateRequest.js
@@ -1,0 +1,9 @@
+import { validationResult } from 'express-validator'
+
+export const handleValidationErrors = (req, res, next) => {
+	const errors = validationResult(req)
+	if (!errors.isEmpty()) {
+		return res.status(400).json({ errors: errors.array() })
+	}
+	next()
+}

--- a/back-end/src/models/userModel.js
+++ b/back-end/src/models/userModel.js
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose'
+
+const userSchema = new mongoose.Schema(
+	{
+		email: {
+			type: String,
+			required: true,
+			unique: true,
+			lowercase: true,
+			trim: true,
+			maxlength: 320,
+		},
+		passwordHash: {
+			type: String,
+			required: true,
+		},
+		displayName: {
+			type: String,
+			default: '',
+			trim: true,
+			maxlength: 100,
+		},
+		avatarUrl: {
+			type: String,
+			default: '',
+			trim: true,
+			maxlength: 2048,
+		},
+		bio: {
+			type: String,
+			default: '',
+			trim: true,
+			maxlength: 500,
+		},
+	},
+	{
+		timestamps: true,
+	}
+)
+
+export const User = mongoose.model('User', userSchema)

--- a/back-end/src/routes/authRoutes.js
+++ b/back-end/src/routes/authRoutes.js
@@ -1,0 +1,57 @@
+import { Router } from 'express'
+import { body } from 'express-validator'
+
+import { login, me, register } from '../controllers/authController.js'
+import { requireAuth } from '../middleware/authMiddleware.js'
+import { handleValidationErrors } from '../middleware/validateRequest.js'
+
+const router = Router()
+
+const registerBody = [
+	body('email').trim().normalizeEmail().isEmail().withMessage('Valid email required'),
+	body('password')
+		.isString()
+		.isLength({ min: 8, max: 128 })
+		.withMessage('Password must be between 8 and 128 characters'),
+	body('displayName')
+		.optional()
+		.isString()
+		.trim()
+		.isLength({ max: 100 })
+		.withMessage('Display name too long'),
+	body('bio')
+		.optional()
+		.isString()
+		.trim()
+		.isLength({ max: 500 })
+		.withMessage('Bio too long'),
+	body('avatarUrl')
+		.optional()
+		.isString()
+		.trim()
+		.custom((value) => {
+			if (!value) return true
+			try {
+				const u = new URL(value)
+				return Boolean(u.protocol === 'http:' || u.protocol === 'https:')
+			} catch {
+				throw new Error('avatarUrl must be a valid HTTP or HTTPS URL')
+			}
+		}),
+]
+
+const loginBody = [
+	body('email').trim().normalizeEmail().isEmail().withMessage('Valid email required'),
+	body('password').isString().notEmpty().withMessage('Password required'),
+]
+
+const registerMiddleware = [...registerBody, handleValidationErrors, register]
+const loginMiddleware = [...loginBody, handleValidationErrors, login]
+
+router.post('/api/auth/register', ...registerMiddleware)
+router.post('/api/auth/signup', ...registerMiddleware)
+router.post('/api/auth/login', ...loginMiddleware)
+router.post('/api/auth/signin', ...loginMiddleware)
+router.get('/api/me', requireAuth, me)
+
+export default router

--- a/back-end/test/auth.routes.test.js
+++ b/back-end/test/auth.routes.test.js
@@ -1,0 +1,154 @@
+import { expect } from 'chai'
+import mongoose from 'mongoose'
+import request from 'supertest'
+
+import app from '../server.js'
+import { connectToDatabase } from '../src/config/database.js'
+import { User } from '../src/models/userModel.js'
+
+const runAuthIntegration = !!(process.env.MONGODB_URI && process.env.JWT_SECRET)
+
+;(runAuthIntegration ? describe : describe.skip)('Authentication API (#155 #169)', function () {
+	this.timeout(20_000)
+
+	before(async () => {
+		if (mongoose.connection.readyState !== 1) {
+			await connectToDatabase()
+		}
+	})
+
+	const uniqEmail = () =>
+		`auth-test-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`
+
+	it('POST /api/auth/register returns JWT (201)', async () => {
+		const email = uniqEmail()
+		const res = await request(app).post('/api/auth/register').send({
+			email,
+			password: 'correcthorse',
+			displayName: 'Route Test User',
+			bio: 'Hi',
+			avatarUrl: 'https://example.com/a.png',
+		})
+
+		expect(res.status).to.equal(201)
+		expect(res.body).to.have.property('token').that.is.a('string').with.length.gt(12)
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('POST /api/auth/signup matches register behavior', async () => {
+		const email = uniqEmail()
+		const res = await request(app).post('/api/auth/signup').send({
+			email,
+			password: 'correcthorse',
+		})
+
+		expect(res.status).to.equal(201)
+		expect(res.body).to.have.property('token')
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('rejects duplicate email (409)', async () => {
+		const email = uniqEmail()
+		const first = await request(app).post('/api/auth/register').send({
+			email,
+			password: 'correcthorse',
+		})
+
+		expect(first.status).to.equal(201)
+
+		const dup = await request(app).post('/api/auth/register').send({
+			email,
+			password: 'anotherpwd1',
+		})
+
+		expect(dup.status).to.equal(409)
+		expect(dup.body.error).to.match(/already|use/i)
+
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('POST /api/auth/login returns token when password matches', async () => {
+		const email = uniqEmail()
+
+		await request(app).post('/api/auth/register').send({
+			email,
+			password: 'matchingpwd1',
+		})
+
+		const res = await request(app).post('/api/auth/login').send({
+			email,
+			password: 'matchingpwd1',
+		})
+
+		expect(res.status).to.equal(200)
+		expect(res.body).to.have.property('token')
+
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('POST /api/auth/signin matches login behavior', async () => {
+		const email = uniqEmail()
+
+		await request(app).post('/api/auth/register').send({
+			email,
+			password: 'signinPWD1!',
+		})
+
+		const res = await request(app).post('/api/auth/signin').send({
+			email,
+			password: 'signinPWD1!',
+		})
+
+		expect(res.status).to.equal(200)
+		expect(res.body).to.have.property('token')
+
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('blocks login when password incorrect (401)', async () => {
+		const email = uniqEmail()
+
+		await request(app).post('/api/auth/register').send({
+			email,
+			password: 'rightpassword1',
+		})
+
+		const res = await request(app).post('/api/auth/login').send({
+			email,
+			password: 'wrongpassword!',
+		})
+
+		expect(res.status).to.equal(401)
+		expect(res.body.error).to.match(/invalid/i)
+
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+
+	it('GET /api/me requires Bearer token', async () => {
+		const res = await request(app).get('/api/me')
+		expect(res.status).to.equal(401)
+	})
+
+	it('GET /api/me returns profile with valid token', async () => {
+		const email = uniqEmail()
+
+		const reg = await request(app).post('/api/auth/register').send({
+			email,
+			password: 'profilePwd1!',
+			displayName: 'Me Tester',
+			bio: 'Hello',
+			avatarUrl: 'https://example.com/p.png',
+		})
+
+		const token = reg.body.token
+
+		const res = await request(app).get('/api/me').set('Authorization', `Bearer ${token}`)
+
+		expect(res.status).to.equal(200)
+		expect(res.body).to.include.keys('id', 'email', 'displayName', 'bio', 'avatarUrl')
+		expect(res.body.email).to.equal(email.trim().toLowerCase())
+		expect(res.body.displayName).to.equal('Me Tester')
+
+		await User.deleteOne({ email: email.trim().toLowerCase() })
+	})
+})

--- a/back-end/test/routes/presetFilter.test.js
+++ b/back-end/test/routes/presetFilter.test.js
@@ -19,10 +19,8 @@ describe('Preset filter routes', () => {
     })
 
     it('returns 400 for invalid preset values', async () => {
-        const mediaId = await uploadTestImage(app)
-
         const res = await request(app).post('/api/filter/image').send({
-            mediaId,
+            mediaId: '507f1f77bcf86cd799439011',
             preset: 'invalid-preset',
         })
 

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -23,9 +23,13 @@ Front-end tests are organized under a single top-level folder:
 
 This mirrors the back-end convention (`back-end/test/**`) for consistent project structure.
 
-Run the front-end unit tests:
+Run the front-end unit tests (single run, exits when finished):
 
-- `npm test`
+- `npm test -- --run`
+
+From the repository root:
+
+- `cd front-end && npm test -- --run`
 
 Run in watch mode while developing:
 

--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1602,6 +1602,29 @@ input[type='range']::-moz-range-thumb {
   border-radius: 4px;
 }
 
+.auth-dev-guest-btn {
+  margin-top: 0.25rem;
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.35rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font-family: inherit;
+}
+
+.auth-dev-guest-btn:hover {
+  color: #555;
+}
+
+.auth-dev-guest-btn:focus-visible {
+  outline: 2px solid rgba(100, 108, 255, 0.35);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .auth-card {
   width: 100%;
   max-width: 360px;

--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -1602,29 +1602,6 @@ input[type='range']::-moz-range-thumb {
   border-radius: 4px;
 }
 
-.auth-dev-guest-btn {
-  margin-top: 0.25rem;
-  background: none;
-  border: none;
-  color: #888;
-  font-size: 0.8rem;
-  cursor: pointer;
-  padding: 0.35rem;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  font-family: inherit;
-}
-
-.auth-dev-guest-btn:hover {
-  color: #555;
-}
-
-.auth-dev-guest-btn:focus-visible {
-  outline: 2px solid rgba(100, 108, 255, 0.35);
-  outline-offset: 2px;
-  border-radius: 4px;
-}
-
 .auth-card {
   width: 100%;
   max-width: 360px;

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import './App.css'
-import {
-  clearAuthToken,
-  clearDevGuestSession,
-  DEV_GUEST_PROFILE,
-  getAuthToken,
-  isDevGuestSession,
-  setDevGuestSession,
-} from './auth/authSession.js'
+import { clearAuthToken, getAuthToken } from './auth/authSession.js'
 import AuthLanding from './components/AuthLanding'
 import EditorContainer from './components/EditorContainer'
 import HomeView from './components/HomeView'
@@ -31,21 +24,16 @@ const APP_VIEWS = {
 
 function App() {
   const [appScreen, setAppScreen] = useState(() =>
-    getAuthToken() || isDevGuestSession() ? APP_SCREENS.APP : APP_SCREENS.LANDING
+    getAuthToken() ? APP_SCREENS.APP : APP_SCREENS.LANDING
   )
-  const [isAuthenticated, setIsAuthenticated] = useState(() =>
-    getAuthToken() ? false : Boolean(isDevGuestSession())
-  )
-  const [currentUser, setCurrentUser] = useState(() =>
-    isDevGuestSession() && !getAuthToken() ? DEV_GUEST_PROFILE : null
-  )
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [currentUser, setCurrentUser] = useState(null)
   const [activeView, setActiveView] = useState(APP_VIEWS.HOME)
   const [creationsRefreshKey, setCreationsRefreshKey] = useState(0)
   const loadDraftRef = useRef(null)
 
   useEffect(() => {
     const onExpire = () => {
-      clearDevGuestSession()
       setCurrentUser(null)
       setIsAuthenticated(false)
       setAppScreen(APP_SCREENS.SIGN_IN)
@@ -64,7 +52,6 @@ function App() {
         setCurrentUser(user)
         setIsAuthenticated(true)
         setAppScreen(APP_SCREENS.APP)
-        clearDevGuestSession()
       } catch {
         if (!cancelled) {
           clearAuthToken()
@@ -83,9 +70,6 @@ function App() {
     setTimeout(() => loadDraftRef.current?.(creation), 0)
   }, [])
 
-  const showDevGuestEntry =
-    import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_GUEST === 'true'
-
   if (appScreen === APP_SCREENS.LANDING) {
     return (
       <AuthLanding
@@ -93,21 +77,10 @@ function App() {
         onSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
         onGuest={() => {
           clearAuthToken()
-          clearDevGuestSession()
           setCurrentUser(null)
           setIsAuthenticated(false)
           setAppScreen(APP_SCREENS.APP)
         }}
-        onDevGuest={
-          showDevGuestEntry
-            ? () => {
-                setDevGuestSession()
-                setCurrentUser(DEV_GUEST_PROFILE)
-                setIsAuthenticated(true)
-                setAppScreen(APP_SCREENS.APP)
-              }
-            : undefined
-        }
       />
     )
   }

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,11 +1,20 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import './App.css'
+import {
+  clearAuthToken,
+  clearDevGuestSession,
+  DEV_GUEST_PROFILE,
+  getAuthToken,
+  isDevGuestSession,
+  setDevGuestSession,
+} from './auth/authSession.js'
 import AuthLanding from './components/AuthLanding'
 import EditorContainer from './components/EditorContainer'
 import HomeView from './components/HomeView'
 import MyCreationsPage from './components/MyCreationsPage'
 import SignInPage from './components/SignInPage'
 import SignUpPage from './components/SignUpPage'
+import * as authApi from './services/authApi.js'
 
 const APP_SCREENS = {
   LANDING: 'landing',
@@ -21,23 +30,84 @@ const APP_VIEWS = {
 }
 
 function App() {
-  const [appScreen, setAppScreen] = useState(APP_SCREENS.LANDING)
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [appScreen, setAppScreen] = useState(() =>
+    getAuthToken() || isDevGuestSession() ? APP_SCREENS.APP : APP_SCREENS.LANDING
+  )
+  const [isAuthenticated, setIsAuthenticated] = useState(() =>
+    getAuthToken() ? false : Boolean(isDevGuestSession())
+  )
+  const [currentUser, setCurrentUser] = useState(() =>
+    isDevGuestSession() && !getAuthToken() ? DEV_GUEST_PROFILE : null
+  )
   const [activeView, setActiveView] = useState(APP_VIEWS.HOME)
   const [creationsRefreshKey, setCreationsRefreshKey] = useState(0)
   const loadDraftRef = useRef(null)
+
+  useEffect(() => {
+    const onExpire = () => {
+      clearDevGuestSession()
+      setCurrentUser(null)
+      setIsAuthenticated(false)
+      setAppScreen(APP_SCREENS.SIGN_IN)
+    }
+    window.addEventListener('auth:session-expired', onExpire)
+    return () => window.removeEventListener('auth:session-expired', onExpire)
+  }, [])
+
+  useEffect(() => {
+    if (!getAuthToken()) return undefined
+    let cancelled = false
+    ;(async () => {
+      try {
+        const user = await authApi.fetchCurrentUser()
+        if (cancelled) return
+        setCurrentUser(user)
+        setIsAuthenticated(true)
+        setAppScreen(APP_SCREENS.APP)
+        clearDevGuestSession()
+      } catch {
+        if (!cancelled) {
+          clearAuthToken()
+          setIsAuthenticated(false)
+          setCurrentUser(null)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleSelectCreation = useCallback((creation) => {
     setActiveView(APP_VIEWS.CREATE)
     setTimeout(() => loadDraftRef.current?.(creation), 0)
   }, [])
 
+  const showDevGuestEntry =
+    import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_GUEST === 'true'
+
   if (appScreen === APP_SCREENS.LANDING) {
     return (
       <AuthLanding
         onSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
         onSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
-        onGuest={() => setAppScreen(APP_SCREENS.APP)}
+        onGuest={() => {
+          clearAuthToken()
+          clearDevGuestSession()
+          setCurrentUser(null)
+          setIsAuthenticated(false)
+          setAppScreen(APP_SCREENS.APP)
+        }}
+        onDevGuest={
+          showDevGuestEntry
+            ? () => {
+                setDevGuestSession()
+                setCurrentUser(DEV_GUEST_PROFILE)
+                setIsAuthenticated(true)
+                setAppScreen(APP_SCREENS.APP)
+              }
+            : undefined
+        }
       />
     )
   }
@@ -45,7 +115,11 @@ function App() {
   if (appScreen === APP_SCREENS.SIGN_IN) {
     return (
       <SignInPage
-        onSignIn={() => { setIsAuthenticated(true); setAppScreen(APP_SCREENS.APP) }}
+        onSuccess={(user) => {
+          setCurrentUser(user)
+          setIsAuthenticated(true)
+          setAppScreen(APP_SCREENS.APP)
+        }}
         onBack={() => setAppScreen(APP_SCREENS.LANDING)}
         onGoSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
       />
@@ -55,7 +129,11 @@ function App() {
   if (appScreen === APP_SCREENS.SIGN_UP) {
     return (
       <SignUpPage
-        onSignUp={() => { setIsAuthenticated(true); setAppScreen(APP_SCREENS.APP) }}
+        onSuccess={(user) => {
+          setCurrentUser(user)
+          setIsAuthenticated(true)
+          setAppScreen(APP_SCREENS.APP)
+        }}
         onBack={() => setAppScreen(APP_SCREENS.LANDING)}
         onGoSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
       />
@@ -80,9 +158,15 @@ function App() {
           refreshKey={creationsRefreshKey}
           onSelectCreation={handleSelectCreation}
           isAuthenticated={isAuthenticated}
+          currentUser={currentUser}
           onGoSignIn={() => setAppScreen(APP_SCREENS.SIGN_IN)}
           onGoSignUp={() => setAppScreen(APP_SCREENS.SIGN_UP)}
-          onSignOut={() => { setIsAuthenticated(false); setAppScreen(APP_SCREENS.LANDING) }}
+          onSignOut={() => {
+            authApi.logoutSession()
+            setCurrentUser(null)
+            setIsAuthenticated(false)
+            setAppScreen(APP_SCREENS.LANDING)
+          }}
         />
       )
     }

--- a/front-end/src/auth/authSession.js
+++ b/front-end/src/auth/authSession.js
@@ -1,0 +1,53 @@
+const STORAGE_KEY = 'stickercreate_auth_token'
+const DEV_GUEST_KEY = 'stickercreate_dev_guest'
+
+export const DEV_GUEST_PROFILE = {
+  email: 'guest@local.dev',
+  displayName: 'Dev Guest',
+  bio: 'No server account; drafts use this browser ownerKey.',
+}
+
+export const getAuthToken = () => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return v && typeof v === 'string' ? v.trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+export const setAuthToken = (token) => {
+  try {
+    if (token && typeof token === 'string') {
+      localStorage.setItem(STORAGE_KEY, token.trim())
+      localStorage.removeItem(DEV_GUEST_KEY)
+    }
+  } catch {}
+}
+
+export const clearAuthToken = () => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {}
+}
+
+export const setDevGuestSession = () => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+    localStorage.setItem(DEV_GUEST_KEY, '1')
+  } catch {}
+}
+
+export const clearDevGuestSession = () => {
+  try {
+    localStorage.removeItem(DEV_GUEST_KEY)
+  } catch {}
+}
+
+export const isDevGuestSession = () => {
+  try {
+    return localStorage.getItem(DEV_GUEST_KEY) === '1' && !getAuthToken()
+  } catch {
+    return false
+  }
+}

--- a/front-end/src/auth/authSession.js
+++ b/front-end/src/auth/authSession.js
@@ -1,11 +1,4 @@
 const STORAGE_KEY = 'stickercreate_auth_token'
-const DEV_GUEST_KEY = 'stickercreate_dev_guest'
-
-export const DEV_GUEST_PROFILE = {
-  email: 'guest@local.dev',
-  displayName: 'Dev Guest',
-  bio: 'No server account; drafts use this browser ownerKey.',
-}
 
 export const getAuthToken = () => {
   try {
@@ -20,7 +13,6 @@ export const setAuthToken = (token) => {
   try {
     if (token && typeof token === 'string') {
       localStorage.setItem(STORAGE_KEY, token.trim())
-      localStorage.removeItem(DEV_GUEST_KEY)
     }
   } catch {
     void 0
@@ -32,30 +24,5 @@ export const clearAuthToken = () => {
     localStorage.removeItem(STORAGE_KEY)
   } catch {
     void 0
-  }
-}
-
-export const setDevGuestSession = () => {
-  try {
-    localStorage.removeItem(STORAGE_KEY)
-    localStorage.setItem(DEV_GUEST_KEY, '1')
-  } catch {
-    void 0
-  }
-}
-
-export const clearDevGuestSession = () => {
-  try {
-    localStorage.removeItem(DEV_GUEST_KEY)
-  } catch {
-    void 0
-  }
-}
-
-export const isDevGuestSession = () => {
-  try {
-    return localStorage.getItem(DEV_GUEST_KEY) === '1' && !getAuthToken()
-  } catch {
-    return false
   }
 }

--- a/front-end/src/auth/authSession.js
+++ b/front-end/src/auth/authSession.js
@@ -22,26 +22,34 @@ export const setAuthToken = (token) => {
       localStorage.setItem(STORAGE_KEY, token.trim())
       localStorage.removeItem(DEV_GUEST_KEY)
     }
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const clearAuthToken = () => {
   try {
     localStorage.removeItem(STORAGE_KEY)
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const setDevGuestSession = () => {
   try {
     localStorage.removeItem(STORAGE_KEY)
     localStorage.setItem(DEV_GUEST_KEY, '1')
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const clearDevGuestSession = () => {
   try {
     localStorage.removeItem(DEV_GUEST_KEY)
-  } catch {}
+  } catch {
+    void 0
+  }
 }
 
 export const isDevGuestSession = () => {

--- a/front-end/src/components/AuthLanding.jsx
+++ b/front-end/src/components/AuthLanding.jsx
@@ -1,4 +1,4 @@
-function AuthLanding({ onSignIn, onSignUp, onGuest, onDevGuest }) {
+function AuthLanding({ onSignIn, onSignUp, onGuest }) {
   return (
     <div className="auth-screen">
       <div className="auth-landing-brand">
@@ -15,11 +15,6 @@ function AuthLanding({ onSignIn, onSignUp, onGuest, onDevGuest }) {
         <button type="button" className="auth-guest-btn" onClick={onGuest}>
           Continue as Guest
         </button>
-        {onDevGuest ? (
-          <button type="button" className="auth-dev-guest-btn" onClick={onDevGuest}>
-            Dev session (no backend login)
-          </button>
-        ) : null}
       </div>
     </div>
   )

--- a/front-end/src/components/AuthLanding.jsx
+++ b/front-end/src/components/AuthLanding.jsx
@@ -1,4 +1,4 @@
-function AuthLanding({ onSignIn, onSignUp, onGuest }) {
+function AuthLanding({ onSignIn, onSignUp, onGuest, onDevGuest }) {
   return (
     <div className="auth-screen">
       <div className="auth-landing-brand">
@@ -15,6 +15,11 @@ function AuthLanding({ onSignIn, onSignUp, onGuest }) {
         <button type="button" className="auth-guest-btn" onClick={onGuest}>
           Continue as Guest
         </button>
+        {onDevGuest ? (
+          <button type="button" className="auth-dev-guest-btn" onClick={onDevGuest}>
+            Dev session (no backend login)
+          </button>
+        ) : null}
       </div>
     </div>
   )

--- a/front-end/src/components/MyCreationsPage.jsx
+++ b/front-end/src/components/MyCreationsPage.jsx
@@ -59,6 +59,32 @@ const formatUpdated = (iso) => {
   }
 }
 
+const profileDisplayName = (user) => {
+  const d = user?.displayName?.trim()
+  if (d) return d
+  const e = user?.email?.trim()
+  if (e) return e
+  return 'Your Name'
+}
+
+const profileBioText = (user) => {
+  const b = user?.bio?.trim()
+  if (b) return b
+  return 'No bio yet.'
+}
+
+const profileInitials = (user) => {
+  const dn = user?.displayName?.trim()
+  if (dn) {
+    const parts = dn.split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase().slice(0, 2)
+    if (parts[0]) return parts[0].slice(0, 2).toUpperCase()
+  }
+  const em = user?.email?.trim()
+  if (em) return em.slice(0, 2).toUpperCase()
+  return 'SC'
+}
+
 function GuestProfileView({ onGoSignIn, onGoSignUp }) {
   return (
     <div className="profile-guest">
@@ -91,6 +117,7 @@ function MyCreationsPage({
   refreshKey = 0,
   onSelectCreation,
   isAuthenticated = true,
+  currentUser = null,
   onGoSignIn,
   onGoSignUp,
   onSignOut,
@@ -458,11 +485,11 @@ function MyCreationsPage({
     <div className="profile-page" role="region" aria-label="Profile">
       <div className="profile-header">
         <div className="profile-avatar" aria-hidden="true">
-          <span className="profile-avatar-initials">SC</span>
+          <span className="profile-avatar-initials">{profileInitials(currentUser)}</span>
         </div>
 
-        <p className="profile-name">Your Name</p>
-        <p className="profile-bio">No bio yet.</p>
+        <p className="profile-name">{profileDisplayName(currentUser)}</p>
+        <p className="profile-bio">{profileBioText(currentUser)}</p>
 
         <div className="profile-socials">
           <button type="button" className="profile-social-link">

--- a/front-end/src/components/SignInPage.jsx
+++ b/front-end/src/components/SignInPage.jsx
@@ -1,12 +1,24 @@
 import { useState } from 'react'
+import * as authApi from '../services/authApi.js'
 
-function SignInPage({ onSignIn, onBack, onGoSignUp }) {
+function SignInPage({ onSuccess, onBack, onGoSignUp }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    onSignIn()
+    setError('')
+    setSubmitting(true)
+    try {
+      const user = await authApi.login({ email, password })
+      onSuccess(user)
+    } catch (err) {
+      setError(err?.message || 'Sign in failed')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -16,6 +28,11 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
           ← Back
         </button>
         <h2 className="auth-card-title">Sign In</h2>
+        {error ? (
+          <p className="editor-status editor-status--error" role="alert">
+            {error}
+          </p>
+        ) : null}
         <form className="auth-form" onSubmit={handleSubmit}>
           <div className="auth-field">
             <label htmlFor="signin-email" className="auth-label">
@@ -29,6 +46,7 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              required
             />
           </div>
           <div className="auth-field">
@@ -43,10 +61,11 @@ function SignInPage({ onSignIn, onBack, onGoSignUp }) {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
               autoComplete="current-password"
+              required
             />
           </div>
-          <button type="submit" className="btn-primary auth-action-btn">
-            Sign In
+          <button type="submit" className="btn-primary auth-action-btn" disabled={submitting}>
+            {submitting ? 'Signing in…' : 'Sign In'}
           </button>
         </form>
         <p className="auth-switch-text">

--- a/front-end/src/components/SignUpPage.jsx
+++ b/front-end/src/components/SignUpPage.jsx
@@ -1,13 +1,29 @@
 import { useState } from 'react'
+import * as authApi from '../services/authApi.js'
 
-function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
+function SignUpPage({ onSuccess, onBack, onGoSignIn }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    onSignUp()
+    setError('')
+    if (password !== confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const user = await authApi.register({ email, password })
+      onSuccess(user)
+    } catch (err) {
+      setError(err?.message || 'Registration failed')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -17,6 +33,11 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
           ← Back
         </button>
         <h2 className="auth-card-title">Sign Up</h2>
+        {error ? (
+          <p className="editor-status editor-status--error" role="alert">
+            {error}
+          </p>
+        ) : null}
         <form className="auth-form" onSubmit={handleSubmit}>
           <div className="auth-field">
             <label htmlFor="signup-email" className="auth-label">
@@ -30,6 +51,7 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              required
             />
           </div>
           <div className="auth-field">
@@ -44,6 +66,7 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
               autoComplete="new-password"
+              required
             />
           </div>
           <div className="auth-field">
@@ -58,10 +81,11 @@ function SignUpPage({ onSignUp, onBack, onGoSignIn }) {
               onChange={(e) => setConfirm(e.target.value)}
               placeholder="••••••••"
               autoComplete="new-password"
+              required
             />
           </div>
-          <button type="submit" className="btn-primary auth-action-btn">
-            Create Account
+          <button type="submit" className="btn-primary auth-action-btn" disabled={submitting}>
+            {submitting ? 'Creating…' : 'Create Account'}
           </button>
         </form>
         <p className="auth-switch-text">

--- a/front-end/src/services/authApi.js
+++ b/front-end/src/services/authApi.js
@@ -1,5 +1,5 @@
 import { getJson, postJson } from './backendMediaClient.js'
-import { clearAuthToken, clearDevGuestSession, getAuthToken, setAuthToken } from '../auth/authSession.js'
+import { clearAuthToken, getAuthToken, setAuthToken } from '../auth/authSession.js'
 
 const pickToken = (body) =>
   (body && typeof body === 'object' && (body.token || body.accessToken)) || ''
@@ -37,5 +37,4 @@ export const fetchCurrentUser = async () => {
 
 export const logoutSession = () => {
   clearAuthToken()
-  clearDevGuestSession()
 }

--- a/front-end/src/services/authApi.js
+++ b/front-end/src/services/authApi.js
@@ -1,0 +1,41 @@
+import { getJson, postJson } from './backendMediaClient.js'
+import { clearAuthToken, clearDevGuestSession, getAuthToken, setAuthToken } from '../auth/authSession.js'
+
+const pickToken = (body) =>
+  (body && typeof body === 'object' && (body.token || body.accessToken)) || ''
+
+export const register = async ({ email, password }) => {
+  const body = await postJson({
+    path: '/api/auth/register',
+    payload: { email, password },
+    skipAuth: true,
+    fallbackErrorMessage: 'Registration failed',
+  })
+  const token = pickToken(body)
+  if (!token) throw new Error('Invalid server response')
+  setAuthToken(token)
+  return fetchCurrentUser()
+}
+
+export const login = async ({ email, password }) => {
+  const body = await postJson({
+    path: '/api/auth/login',
+    payload: { email, password },
+    skipAuth: true,
+    fallbackErrorMessage: 'Sign in failed',
+  })
+  const token = pickToken(body)
+  if (!token) throw new Error('Invalid server response')
+  setAuthToken(token)
+  return fetchCurrentUser()
+}
+
+export const fetchCurrentUser = async () => {
+  if (!getAuthToken()) return null
+  return getJson({ path: '/api/me', fallbackErrorMessage: 'Could not load account' })
+}
+
+export const logoutSession = () => {
+  clearAuthToken()
+  clearDevGuestSession()
+}

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -22,7 +22,9 @@ const parseErrorMessage = async (response, fallbackMessage = 'Request failed') =
       if (parts.length) return parts.join(' ')
     }
     if (typeof payload?.message === 'string') return payload.message
-  } catch {}
+  } catch {
+    void 0
+  }
 
   return `${fallbackMessage} (${response.status})`
 }

--- a/front-end/src/services/backendMediaClient.js
+++ b/front-end/src/services/backendMediaClient.js
@@ -1,15 +1,28 @@
+import { clearAuthToken, getAuthToken } from '../auth/authSession.js'
+
 const DEFAULT_BACKEND_BASE_URL = 'http://localhost:4000'
 
 export const getBackendBaseUrl = () =>
   (import.meta.env?.VITE_BACKEND_BASE_URL || DEFAULT_BACKEND_BASE_URL).trim()
 
+const notifyUnauthorized = (skipAuth, hadBearer, status) => {
+  if (status !== 401 || skipAuth || !hadBearer) return
+  clearAuthToken()
+  window.dispatchEvent(new CustomEvent('auth:session-expired'))
+}
+
 const parseErrorMessage = async (response, fallbackMessage = 'Request failed') => {
   try {
     const payload = await response.json()
-    if (payload?.error) return payload.error
-  } catch {
-    // ignore JSON parse errors
-  }
+    if (typeof payload?.error === 'string') return payload.error
+    if (Array.isArray(payload?.errors) && payload.errors.length) {
+      const parts = payload.errors
+        .map((e) => (typeof e === 'string' ? e : e.msg || e.message))
+        .filter(Boolean)
+      if (parts.length) return parts.join(' ')
+    }
+    if (typeof payload?.message === 'string') return payload.message
+  } catch {}
 
   return `${fallbackMessage} (${response.status})`
 }
@@ -20,6 +33,7 @@ export const postMultipart = async ({
   file,
   fields,
   fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
 }) => {
   if (!file) {
     throw new Error('No file provided')
@@ -36,11 +50,15 @@ export const postMultipart = async ({
   }
 
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'POST',
+      headers,
       body: formData,
     })
   } catch {
@@ -48,6 +66,7 @@ export const postMultipart = async ({
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -57,14 +76,22 @@ export const postMultipart = async ({
   return response.json()
 }
 
-export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request failed' }) => {
+export const postJson = async ({
+  path,
+  payload,
+  fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
+}) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = { 'Content-Type': 'application/json' }
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(payload ?? {}),
     })
   } catch {
@@ -72,6 +99,7 @@ export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request 
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -81,17 +109,21 @@ export const postJson = async ({ path, payload, fallbackErrorMessage = 'Request 
   return response.json()
 }
 
-export const getJson = async ({ path, fallbackErrorMessage = 'Request failed' }) => {
+export const getJson = async ({ path, fallbackErrorMessage = 'Request failed', skipAuth = false }) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
-    response = await fetch(endpoint, { method: 'GET' })
+    response = await fetch(endpoint, { method: 'GET', headers })
   } catch {
     throw new Error('Unable to reach backend. Please make sure the backend server is running.')
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -101,17 +133,21 @@ export const getJson = async ({ path, fallbackErrorMessage = 'Request failed' })
   return response.json()
 }
 
-export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed' }) => {
+export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed', skipAuth = false }) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = {}
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
-    response = await fetch(endpoint, { method: 'DELETE' })
+    response = await fetch(endpoint, { method: 'DELETE', headers })
   } catch {
     throw new Error('Unable to reach backend. Please make sure the backend server is running.')
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status
@@ -121,14 +157,22 @@ export const deleteJson = async ({ path, fallbackErrorMessage = 'Request failed'
   return response.json()
 }
 
-export const patchJson = async ({ path, payload, fallbackErrorMessage = 'Request failed' }) => {
+export const patchJson = async ({
+  path,
+  payload,
+  fallbackErrorMessage = 'Request failed',
+  skipAuth = false,
+}) => {
   const endpoint = `${getBackendBaseUrl()}${path}`
+  const tokenAtStart = skipAuth ? '' : getAuthToken()
+  const headers = { 'Content-Type': 'application/json' }
+  if (tokenAtStart) headers.Authorization = `Bearer ${tokenAtStart}`
 
   let response
   try {
     response = await fetch(endpoint, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(payload ?? {}),
     })
   } catch {
@@ -136,6 +180,7 @@ export const patchJson = async ({ path, payload, fallbackErrorMessage = 'Request
   }
 
   if (!response.ok) {
+    notifyUnauthorized(skipAuth, Boolean(tokenAtStart), response.status)
     const message = await parseErrorMessage(response, fallbackErrorMessage)
     const error = new Error(message)
     error.status = response.status


### PR DESCRIPTION
## Summary
- Closes #155 ; Closes #169 : Mongoose `User` with bcrypt `passwordHash`; `express-validator` on auth bodies before DB; JWT (HS256) on register/signup/login/signin; `requireAuth` + `GET /api/me`; same handlers on `/api/auth/register|signup` and `/api/auth/login|signin`; secrets via `.env` + `.env.example`.
- **#156 (front-end):** Sign-in/up call API, store JWT, send `Authorization: Bearer`, handle errors/401/`/api/me` profile wiring (as merged in branch).

## Test plan
- [x] `cd back-end && npm test`
- [x] `cd front-end && npm test -- --run`
- [x] Manual: register → logged in → Profile; wrong password rejected; duplicate email rejected